### PR TITLE
Update link to repo in FAQ

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -86,7 +86,7 @@ The code for this site is open source, that means you can contribute to making t
 2. Click the **fork** button near the top right. This copies a version to your account.
 3. In your fork, click the link to the **docs** folder, then click the **faq.md** file. That's the [markdown](https://help.github.com/articles/github-flavored-markdown) file with the content for this page.
 4. Click **Edit** and make your changes. When you're finished, click **Commit** at the bottom.
-5. Return to [this page's repository](http://www.github.com/government.github.com) and click **Pull Request** and then **New Pull Request**. Fill out the form to explain the changes you've made.
+5. Return to [this page's repository](http://www.github.com/github/government.github.com) and click **Pull Request** and then **New Pull Request**. Fill out the form to explain the changes you've made.
 6. Click submit!
 
 _Learn more abut these terms in the [Glossary](https://help.github.com/articles/github-glossary){: target="_blank"}._


### PR DESCRIPTION
The organization name was missing from the URL, leading to a 404.
