### PR TITLE
Add virtual-world-framework organization to site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -37,6 +37,7 @@ organizations:
     - usepa
     - usgs
     - usnationalarchives
+    - virtual-world-framework
     - whitehouse
 #   - USDA-ERS
 #   - usinterior


### PR DESCRIPTION
The virtual world framework is being developed for use by the different branches of the armed forces and is funded by the US Office of the Secretary of Defense. See the FAQ page for more info: http://virtualworldframework.com/web/faq.html
