### PR TITLE
Addition of hpc account.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,6 +15,7 @@ organizations:
     - gsa-ocsit
     - hhs
     - historyatstate
+    - hpc
     - imls
     - libraryofcongress
     - losalamos


### PR DESCRIPTION
The hpc account is used (almost exclusively) by US national labs.
