### PR TITLE
Update _config.yml to add City of Greater Sudbury

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -48,6 +48,7 @@ organizations:
     - gcba
 
   Canada:
+    - cityofgreatersudbury
     - nsgov
     - pwgsc
 


### PR DESCRIPTION
Added the City of Greater Sudbury's github account to _config.yml.  The City of Greater Sudbury is a municipality located in Northern Ontario, Canada. 

http://www.greatersudbury.ca
