### PR TITLE
Added cleveland metroparks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ organizations:
     - adlnet
     - cfpb
     - chaos
-    - cleveland-metroparks
     - cmsgov
     - commercegov
     - department-of-veterans-affairs
@@ -78,6 +77,9 @@ organizations:
   U.S. County:
     - sfcta
     - miamidade
+  
+  U.S. Special District:
+    - cleveland-metroparks
 
   U.S. City:
     - chicago

--- a/_config.yml
+++ b/_config.yml
@@ -5,6 +5,7 @@ organizations:
     - adlnet
     - cfpb
     - chaos
+    - cleveland-metroparks
     - cmsgov
     - commercegov
     - department-of-veterans-affairs


### PR DESCRIPTION
Adding Cleveland Metroparks as a gov agency in the list of USA agencies.
