### PR TITLE
Added Utah's GIS shop to US States

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,7 @@ organizations:
     - vvk-ehk
 
   U.S. States:
+    - agrc
     - nysenate
 #    - wsdot
     - nys-its


### PR DESCRIPTION
added the Utah Automated Geographic Reference center. http://gis.utah.gov
