### PR TITLE
Change references of gov.github.com to government.github.com

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ This guide is intended to be given to government rock stars, to help us better t
 
 ## Background
 
-Gov.github.com is going to be a government-centric blog dedicated to showcasing and amplifying best practices and first-of-their-kind efforts within government around open source, open data, and open government. In addition to a series of short, informal blog posts written by civicly-minded Hubbers or by the public via pull request ("stories"), the completely open source microsite will also curate government-specific collaboratively edited documentation such as FAQs, or links to the public-facing GitHub profiles of government agencies.
+Government.github.com is going to be a government-centric blog dedicated to showcasing and amplifying best practices and first-of-their-kind efforts within government around open source, open data, and open government. In addition to a series of short, informal blog posts written by civicly-minded Hubbers or by the public via pull request ("stories"), the completely open source microsite will also curate government-specific collaboratively edited documentation such as FAQs, or links to the public-facing GitHub profiles of government agencies.
 
 ## Voice
 

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
-  "name": "gov.github.com",
+  "name": "government.github.com",
   "version": "0.0.2",
   "devDependencies": {
     "coffee-script": "latest"
   },
   "readmeFilename": "readme.md",
   "gitHead": "9d267504e75e3104107acc0c49885cc1a3d9f1c9",
-  "description": "*The [gov.github.com](http://gov.github.com) of the future, here today.*",
+  "description": "*The [government.github.com](http://government.github.com) of the future, here today.*",
   "main": "script/server",
   "dependencies": {},
   "scripts": {
@@ -14,11 +14,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/github/gov.github.com.git"
+    "url": "https://github.com/github/government.github.com.git"
   },
   "author": "GitHub, Inc.",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/github/gov.github.com/issues"
+    "url": "https://github.com/github/government.github.com/issues"
   }
 }


### PR DESCRIPTION
The title says it all; using gov.github.com leads to a 404 (the same applies for anything repository related that uses gov.github.com).
