### PR TITLE
Fix Reversed A/B references for Collaborate Section

### DIFF
--- a/features.md
+++ b/features.md
@@ -14,7 +14,7 @@ permalink: /features/
 
 ![Collaborate](/assets/img/collaborating.png)
 
-GitHub Issues lets you create discussion around text, proposed changes or just ideas. You can embed images (**A**), ping other users or teams (**B**) and write in Markdown.
+GitHub Issues lets you create discussion around text, proposed changes or just ideas. You can ping other users or teams (**A**), embed images (**B**) and write in Markdown.
 {: .mini-section }
 
 ## View


### PR DESCRIPTION
In the Collaborate section, the references to A and B on the associated example were reversed.
