### PR TITLE
Adding OKF Brasil

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -52,6 +52,7 @@ organizations:
   Brazil:
     - interlegis
     - plonegovbr
+    - okfn-brasil
 
   Canada:
     - cityofgreatersudbury


### PR DESCRIPTION
OKF Brasil is the local group (soon a chapter) of the Open Knowledge Foundation in Brazil.

See more information at http://br.okfn.org
