### PR TITLE
Adds thacker to the Civic Hackers list

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -142,6 +142,7 @@ organizations:
     - mysociety
     - openaustralia
     - okfn-brasil
+    - thacker
 
 #global settings
 title: "Make government better, together."


### PR DESCRIPTION
This is the brazilian Transparência Hacker group (https://groups.google.com/forum/#!forum/thackday).
