### PR TITLE
Delightful 404 page

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,14 @@
+---
+layout: page
+title: Four oh four
+---
+
+## Looks like the page you requested wasn't found :(
+
+<script type="text/javascript">
+  var GOOG_FIXURL_LANG = 'en';
+  var GOOG_FIXURL_SITE = 'http://government.github.com
+</script>
+<script type="text/javascript"
+  src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
+</script>

--- a/404.md
+++ b/404.md
@@ -14,3 +14,9 @@ title: Not found
 <script type="text/javascript"
   src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
 </script>
+
+### Looking for other cool stuff? Here's some recent stories.
+
+{% for story in site.posts | limit: 3 %}
+* [{{ story.title }}]({{ story.url }})
+{% endfor %}

--- a/404.md
+++ b/404.md
@@ -1,13 +1,15 @@
 ---
 layout: page
-title: Four oh four
+title: Not found
 ---
 
-## Looks like the page you requested wasn't found :(
+## The page you're looking for doesn't seem to be there!
+
+### Maybe we can find it together if you search below.
 
 <script type="text/javascript">
   var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = 'http://government.github.com
+  var GOOG_FIXURL_SITE = 'http://government.github.com';
 </script>
 <script type="text/javascript"
   src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">


### PR DESCRIPTION
Took a first pass at fleshing out a delightful 404 page to replace the current pages default 404.

Dropped in the google 404 widget to hopefully provide some help locating content for now, but may be able to leverage the search API to do something slick here in the long run.

Thoughts on something charming / witty / fun?

![screen shot 2013-10-16 at 12 30 46 pm](https://f.cloud.github.com/assets/282759/1345987/847718e6-3699-11e3-8997-2f79b5b1acc6.png)

Fixes #65.
