### PR TITLE
Fixes footer link to main github.com site

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -14,7 +14,7 @@
 
             <ul class="site-footer-links">
                 <li class="no-mobile">&copy; 2013 GitHub Inc. All rights reserved</li>
-                <li><a href="https://status.github.com/">GitHub.com</a></li>
+                <li><a href="https://github.com/">GitHub.com</a></li>
                 <li class="no-mobile"><a href="/about/">About</a></li>
                 <li class="no-mobile"><a href="/features/">Features</a></li>
 


### PR DESCRIPTION
I guessed the link should point to the main Github website, and not to the status page. If not, than the link text would have to be changed to reflect that.
