### PR TITLE
Remove Google fonts

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -12,8 +12,6 @@
 
   <link rel="stylesheet" href="{{ site.root }}assets/css/style.css">
   <link rel="stylesheet" href="{{ site.root }}assets/css/icons.css">
-  <link href='http://fonts.googleapis.com/css?family=Roboto+Slab:400,100,300,700' rel='stylesheet' type='text/css'>
-  <link href='http://fonts.googleapis.com/css?family=Noticia+Text:400,400italic,700,700italic' rel='stylesheet' type='text/css'>
 
   <script src="{{ site.root }}assets/js/modernizr.js"></script>
 


### PR DESCRIPTION
The fonts are no longer in use in the CSS so we should delete them from the mark up.
