### PR TITLE
Add opennorth to Civic Hackers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -147,6 +147,7 @@ organizations:
     - okfn-brasil
     - dataviz
     - OpenTwinCities
+    - opennorth
 
 #global settings
 title: "Make government better, together."


### PR DESCRIPTION
Some of the other civic hackers (e.g. sunlightlabs, mysociety) rely on our code and [data specifications](http://popoloproject.com/) in their projects – I think that's enough to qualify. [Open North](http://opennorth.ca/) is Canadian.
