### PR TITLE
Move contribute box to top of story, fixes #69

### DIFF
--- a/_layouts/story.html
+++ b/_layouts/story.html
@@ -14,14 +14,11 @@
     <div class="span8 mini-section">
       {{ content }}
     </div>
+    <div class="span4 contribute">
+      <h3>Contribute</h3>
+      <h6>See an error or have a story of your own to tell? This page is open source, so <a href="{{ site.prose_server}}#/github/government.github.com/edit/gh-pages/{{ page.path }}">submit a pull request</a>!</h6>
+    </div>
   </div>
-
-<div class="row">
-  <div class="span4 contribute">
-    <h3>Contribute</h3>
-    <h6>See an error or have a story of your own to tell? This page is open source, so <a href="{{ site.prose_server}}#/github/government.github.com/edit/gh-pages/{{ page.path }}">submit a pull request</a>!</h6>
-  </div>
-</div>
 
 </div>
 


### PR DESCRIPTION
Moving the contribute box to the top so it's easier to see, so that people know and hopefully share stories!

_Also I turned off my sound as to not interrupt the conference I'm at_ :hamburger: 

![screen shot 2013-10-16 at 3 02 59 pm](https://f.cloud.github.com/assets/1305617/1347402/709274ae-36af-11e3-850b-5ae3d4713850.png)
