### PR TITLE
To add "infoculture" as civic hacker

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -150,6 +150,7 @@ organizations:
     - thacker
     - opennorth
     - hasadna
+    - infoculture
 
 #global settings
 title: "Make government better, together."

--- a/_config.yml
+++ b/_config.yml
@@ -124,6 +124,7 @@ organizations:
     - CORaleigh
 
   Civic Hackers:
+    - infoculture
     - codeforamerica
     - sunlightlabs
     - opengovfoundation
@@ -150,7 +151,7 @@ organizations:
     - thacker
     - opennorth
     - hasadna
-    - infoculture
+
 
 #global settings
 title: "Make government better, together."


### PR DESCRIPTION
Infoculture ("Informational culture") is Russian NGO dedicated to open government, opendata and open source.
