### PR TITLE
Added gbv (http://www.gbv.de) library network

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -70,6 +70,9 @@ organizations:
   France:
     - etalab
 
+  Germany:
+    - gbv
+    
   Norway:
     - difi
 


### PR DESCRIPTION
GBV is Germany's largest network of university libraries.
