### PR TITLE
Add required quotes around Google Analytics Property ID

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -1,6 +1,6 @@
 <script>
   var _gaq = _gaq || [];
-  _gaq.push(['_setAccount', {{ site.analytics_account }}]);
+  _gaq.push(['_setAccount', '{{ site.analytics_account }}']);
   _gaq.push(['_trackPageview']);
   (function() {
     var ga = document.createElement('script'); ga.async = true;


### PR DESCRIPTION
![](http://cl.ly/image/2v3q2U2T2o03/Image%202013-10-17%20at%201.03.25%20PM.png)

This should fix Google Analytics reporting, right now it's causing Javascript errors on every page.
