### PR TITLE
Added KoelnAPI to organizations > Germany

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,6 +78,7 @@ organizations:
 
   Germany:
     - gbv
+    - KoelnAPI
 
   Norway:
     - difi


### PR DESCRIPTION
KoelnAPI is a local Open Data community group of Cologne, Germany
