### PR TITLE
added CodeForTomorrow to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -172,6 +172,7 @@ organizations:
     - theodi
     - yourmapper
     - CodeandoMexico
+    - codefortomorrow
 
 #global settings
 title: "Make government better, together."


### PR DESCRIPTION
Code for Tomorrow Foundation Initiative was founded in 2012 and serves as one of the most important organizations on open data and open government from Taiwan.
