### PR TITLE
Added KoelnAPI to organizations > Civic hackers

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -189,6 +189,7 @@ organizations:
     - npp
     - odhk
     - codefortomorrow
+    - KoelnAPI
 
 #global settings
 title: "Make government better, together."


### PR DESCRIPTION
KoelnAPI is a local Open Data community group of Cologne, Germany
