### PR TITLE
[WIP] Add organization metadata

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -298,3 +298,49 @@ prose:
               value: "open data"
             - name: "Open Source"
               value: "open source"
+
+    _orgs:
+      - name: "layout"
+        field:
+          element: "hidden"
+          value: "org"
+      - name: "github"
+        field:
+          element: "text"
+          label: "GitHub org"
+          value: ""
+          type: "text"
+      - name: "fullname"
+        field:
+          element: "text"
+          label: "Full Name"
+          value: ""
+          type: "text"
+      - name: "description"
+        field:
+          element: "textarea"
+          label: "Description"
+          value: ""
+      - name: "categories"
+        field:
+          element: "multiselect"
+          label: "Org Type"
+          placeholder: "Create or choose"
+          options:
+            - name: "Federal Government"
+              value: "fed"
+            - name: "Civic Hacker"
+              value: "civic"
+            - name: "City"
+              value: "city"
+      - name: "country"
+        field:
+          element: "multiselect"
+          label: "Country"
+          placeholder: "Create or choose"
+          options:
+            - name: "United States"
+              value: "fed"
+            - name: "Canada"
+              value: "canada"
+          alterable: true


### PR DESCRIPTION
## Do not merge

Sample of moving organizations from _config.yml to a separate markdown format

![org metadata on prose](https://f.cloud.github.com/assets/1297909/1387533/6beebae2-3b9c-11e3-8944-c06cb02ac3c8.PNG)

This would allow people to write a brief description of the organization and provide the required metadata to categorize them on the Community page.

Related to gh-75
