### PR TITLE
add more UK govt organisations

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -109,6 +109,8 @@ organizations:
     - datagovuk
     - EnvironmentAgency
     - CarersBeta
+    - hmrc
+    - gds-operations
 
   United States:
     - adlnet


### PR DESCRIPTION
hmrc: HM Revenue and Customs repository
gds-operations: Government Digital Service puppet code
