### PR TITLE
Organizations/Norway +kartverket

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -90,6 +90,7 @@ organizations:
 
   Norway:
     - difi
+    - kartverket
 
   Puerto Rico:
     - commonwealth-of-puerto-rico


### PR DESCRIPTION
@kartverket is the National Mapping Authority of Norway.
