### PR TITLE
Update 404.md.

### DIFF
--- a/404.md
+++ b/404.md
@@ -7,12 +7,11 @@ title: Not found
 
 ### Maybe we can find it together if you search below.
 
-<script type="text/javascript">
-  var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = 'http://government.github.com';
+<script>
+  var GOOG_FIXURL_LANG = "en";
+  var GOOG_FIXURL_SITE = "{{ site.url }}";
 </script>
-<script type="text/javascript" src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
-</script>
+<script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
 
 ### Looking for other cool stuff? Here's some recent stories.
 


### PR DESCRIPTION
- use the `site.url` variable
- remove `type="text/javascript"` since it's the default for `script`
- use the protocol relative URL for the 404 widget script
- use double quotes for consistency
