### PR TITLE
css/icons.css: Improve readability of font face.

### DIFF
--- a/assets/css/icons.css
+++ b/assets/css/icons.css
@@ -1,10 +1,14 @@
 @charset "UTF-8";
 @font-face {
-  font-family: 'github-octicons';
+  font-family: "github-octicons";
   src: url("/assets/fonts/github-octicons.eot");
-  src: url("/assets/fonts/github-octicons.eot?#iefix") format("embedded-opentype"), url("/assets/fonts/github-octicons.woff") format("woff"), url("/assets/fonts/github-octicons.ttf") format("truetype"), url("/assets/fonts/github-octicons.svg#github-octicons") format("svg");
+  src: url("/assets/fonts/github-octicons.eot?#iefix") format("embedded-opentype"),
+       url("/assets/fonts/github-octicons.woff") format("woff"),
+       url("/assets/fonts/github-octicons.ttf") format("truetype"),
+       url("/assets/fonts/github-octicons.svg#github-octicons") format("svg");
   font-weight: normal;
-  font-style: normal; }
+  font-style: normal;
+}
 
 .octicon {
   font: normal normal 16px "github-octicons";


### PR DESCRIPTION
Break the long line and use double quotes for consistency.
