### PR TITLE
Be consistent with the quotes type.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
 gem "github-pages"
-gem 'html-proofer'
-gem 'rake'
+gem "html-proofer"
+gem "rake"

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,4 @@
-require 'html/proofer'
+require "html/proofer"
 
 task :test do
   sh "bundle exec jekyll build"

--- a/_config.yml
+++ b/_config.yml
@@ -262,7 +262,7 @@ markdown: kramdown
 # prose settings
 prose_server: "http://prose.io"
 prose:
-  siteurl: 'http://government.github.com'
+  siteurl: "http://government.github.com"
   media: "images"
   metadata:
     _posts:

--- a/_layouts/story.html
+++ b/_layouts/story.html
@@ -4,7 +4,7 @@
   <div class="row">
     <div class="span8">
       <img class="storypage-image {{ page.category }}" src="{{ page.image }}" alt="{{ page.title }}"/>
-      <div class="meta {{ page.category }}"><a class="{{ page.category }}" href="/categories/#{{ page.category | replace: " ","-" }}">{{ page.category }}</a></div>
+      <div class="meta {{ page.category }}"><a class="{{ page.category }}" href="/categories/#{{ page.category | replace: ' ','-' }}">{{ page.category }}</a></div>
       <h1>{{ page.title }}</h1>
       <div class="meta">Published {{ page.date | date: "%B %d, %Y"}} {% if page.author %} by {{ page.author }}{% endif %}</div>
     </div>

--- a/_posts/2013-09-17-design-a-street-with-streetmix.md
+++ b/_posts/2013-09-17-design-a-street-with-streetmix.md
@@ -2,7 +2,7 @@
 layout: story
 author: Jessica Lord, GitHub
 title: Design Street Sections with Streetmix
-description: "Streetmix is an open source civic web application with its code on GitHub. It was created by a handful of 2013 Code for America fellows, each on different teams, who came together to solve a problem."
+description: Streetmix is an open source civic web application with its code on GitHub. It was created by a handful of 2013 Code for America fellows, each on different teams, who came together to solve a problem.
 image: /images/streetmix.png
 category: open source
 ---

--- a/_posts/2013-10-01-modern-approach-to-open-data.md
+++ b/_posts/2013-10-01-modern-approach-to-open-data.md
@@ -2,7 +2,7 @@
 layout: story
 author: Ben Balter, GitHub
 title: A Modern Approach to Open Data
-description: "Developers from the Sunlight Foundation, GovTrack, and the New York Times decided to stop each building the same basic tools over and over, and start building an open data platform they could share."
+description: Developers from the Sunlight Foundation, GovTrack, and the New York Times decided to stop each building the same basic tools over and over, and start building an open data platform they could share.
 image: /images/unitedstates.png
 category: open data
 

--- a/_posts/2013-10-06-forking-your-city.md
+++ b/_posts/2013-10-06-forking-your-city.md
@@ -3,7 +3,7 @@ layout: story
 title: Forking your City
 author: Tom Schenk, City of Chicago
 image: /images/chicago.png
-description: "Chicago has begun releasing select datasets on GitHub in a GeoJSON format and inviting pull requests. So far, Chicago has released the files for bike routes, bike racks, pedway routes, street locations, and building footprints."
+description: Chicago has begun releasing select datasets on GitHub in a GeoJSON format and inviting pull requests. So far, Chicago has released the files for bike routes, bike racks, pedway routes, street locations, and building footprints.
 category: open data
 ---
 

--- a/_posts/2013-10-14-canadian-web-experience-toolkit.md
+++ b/_posts/2013-10-14-canadian-web-experience-toolkit.md
@@ -1,7 +1,7 @@
 ---
 layout: story
 title: Canadian web experience toolkit
-description: "The Web Experience Toolkit (Boîte à outils de l’expérience Web) is an open source code library for building innovative websites that are accessible, usable, interoperable, mobile-friendly and multilingual. This collaborative open source project is led by the Government of Canada."
+description: The Web Experience Toolkit (Boîte à outils de l’expérience Web) is an open source code library for building innovative websites that are accessible, usable, interoperable, mobile-friendly and multilingual. This collaborative open source project is led by the Government of Canada.
 image: /images/wet.png
 category: open source
 author: Ben Balter, GitHub

--- a/_posts/2013-10-28-public-private-collaborations.md
+++ b/_posts/2013-10-28-public-private-collaborations.md
@@ -2,7 +2,7 @@
 layout: story
 author: Spike, OpenOakland
 title: Public-Private Collaborations
-description: " Oakland Answers is a collaborative web site that allows residents easy access to common questions without the usual pain of navigating a city website."
+description: Oakland Answers is a collaborative web site that allows residents easy access to common questions without the usual pain of navigating a city website.
 image: /images/answers.jpg
 category: open source
 ---

--- a/categories.html
+++ b/categories.html
@@ -8,7 +8,7 @@ title: Category Archive
 <div class="row">
   <div class="span8">
     {% for category in site.categories %}
-    <h2 class="story-header" id="{{ category[0] | replace: " ","-" }}">{{ category[0] }}</h2>
+    <h2 class="story-header" id="{{ category[0] | replace: ' ','-' }}">{{ category[0] }}</h2>
     <article class="story-unit">
       {% for post in category[1] %}
       <div class="one-story">

--- a/community.md
+++ b/community.md
@@ -8,7 +8,7 @@ permalink: /community/
   <div class="row">
     <div class="span8">
     {% for type_hash in site.organizations %}
-    <div class="type-block" id="{{ type_hash[0] | downcase | replace:" ","_" }}"><p>{{ type_hash[0] }}</p></div>
+    <div class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}"><p>{{ type_hash[0] }}</p></div>
       {% for org in type_hash[1] %}
         <div class="organization">
           <a href="https://github.com/{{ org }}" title="{{ org }}">

--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ title: GitHub and Government
             <a href="{{ post.url }}">
               <div class="homepage-image {{ post.category }}" style="background-image: url('{{ post.image }}');"></div>
             </a>
-            <div class="meta {{ post.category }}"><a class="{{ post.category }}" href="/categories/#{{ post.category | replace: " ","-" }}">{{ post.category }}</a></div>
+            <div class="meta {{ post.category }}"><a class="{{ post.category }}" href="/categories/#{{ post.category | replace: ' ','-' }}">{{ post.category }}</a></div>
             <h3><a class="title-link {{ post.category }}" href="{{ post.url }}">{{ post.title }}</a></h3>
             <div class="description">{{ post.content | truncatewords: 36 }} <span><a class="read-more" href="{{ post.url }}">read more</a></span></div>
           </article>

--- a/script/fetch-us
+++ b/script/fetch-us
@@ -3,13 +3,13 @@
 #fetches list of US repos from the social media registry, and outputs merged list to command line
 #@todo, can this be done automagically without loosing formatting and comments?
 
-require 'open-uri'
-require 'json'
-require 'yaml'
+require "open-uri"
+require "json"
+require "yaml"
 
-config = YAML.load_file './_config.yml'
+config = YAML.load_file "./_config.yml"
 
-orgs = JSON.parse open('http://registry.usa.gov/accounts?service_id=GitHub&format=json').read
+orgs = JSON.parse open("http://registry.usa.gov/accounts?service_id=GitHub&format=json").read
 orgs = orgs["accounts"].collect { |data| data["account"] }
 
 orgs.each do |org|


### PR DESCRIPTION
- use single quotes inside double quotes
- remove unneeded quotes from posts' descriptions

This change is just cosmetic, since jekyll works fine either way but it's better not to complicate things.
