### PR TITLE
Add CMAP-REPOS to _config.yml

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -181,6 +181,7 @@ organizations:
 
   U.S. Special District:
     - cleveland-metroparks
+    - CMAP-REPOS
 
   U.S. City:
     - chicago


### PR DESCRIPTION
Added CMAP (Chicago Metropolitan Agency for Planning) to U.S. Special Districts
