### PR TITLE
Limit http requests on the home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: home
 title: GitHub and Government
+org_count: 60
 ---
 
 <div class="stories container">
@@ -50,13 +51,17 @@ title: GitHub and Government
   <div class="container">
     <div id="orgs">
       <div class="the-orgs">
+    {% assign count = 0 %}
     {% for type_hash in site.organizations %}
       {% for org in type_hash[1] %}
-        <div class="organization">
-          <a href="https://github.com/{{ org }}" title="{{ org }}">
-            <img class="avatar" src="https://github.com/{{ org }}.png" width="80" height="80" alt="{{ org }}"/>
-          </a>
-        </div>
+        {% if count < page.org_count %}
+          <div class="organization">
+            <a href="https://github.com/{{ org }}" title="{{ org }}">
+              <img class="avatar" src="https://github.com/{{ org }}.png" width="80" height="80" alt="{{ org }}"/>
+            </a>
+          </div>
+        {% endif %}
+        {% assign count = count | plus: 1 %}
       {% endfor %}
     {% endfor %}
       </div> <!-- class="the-orgs" -->


### PR DESCRIPTION
Limit the number of HTTP requests on the index page org logo view to the number visible, which may slow things down, especially as the list grows. This is similar to and influenced by @XhmikosR's efforts in #173 with a few notable changes:
1. Doesn't affect responsiveness 
2. Doesn't affect the visual output
3. I believe the logic of what's actually happening is more immediately apparent 
4. Move the limiting factor to page YML frontmatter for easier changability

@XhmikosR's if this pull request is merged in favor of #173, perhaps it may make sense to open up individual pull requests for 1 and 2 above so that we can give those changes the proper discussion they deserve?

![screen shot 2013-11-05 at 12 19 54 pm](https://f.cloud.github.com/assets/282759/1475636/7e482abe-463e-11e3-8a9d-663e1b9f5b6f.png)

Fixes #151.
