### PR TITLE
CSS cleanup and fixes

### DIFF
--- a/assets/css/icons.css
+++ b/assets/css/icons.css
@@ -7,19 +7,16 @@
        url("/assets/fonts/github-octicons.ttf") format("truetype"),
        url("/assets/fonts/github-octicons.svg#github-octicons") format("svg");
   font-weight: normal;
-  font-style: normal;
-}
+  font-style: normal; }
 
 .octicon {
-  font: normal normal 16px "github-octicons";
-  line-height: 1;
+  font: normal normal 16px/1 "github-octicons";
   display: inline-block;
   text-decoration: none;
   -webkit-font-smoothing: antialiased; }
 
 .mega-octicon {
-  font: normal normal 32px "github-octicons";
-  line-height: 1;
+  font: normal normal 32px/1 "github-octicons";
   display: inline-block;
   text-decoration: none;
   -webkit-font-smoothing: antialiased; }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -449,18 +449,18 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
 /* Media Queries */
 /* ----------------------------------------------------------------------------------- */
 
-@media only screen and (max-width: 979px)  {
+@media (max-width: 979px) {
   .no-mobile { display: none !important; }
 }
 
-@media only screen and (min-width: 650px) and (max-width: 767px) {
+@media (min-width: 650px) and (max-width: 767px) {
   .span4, .span8, .span10, .span12 { width: 100%; }
   nav { float: left; padding-top: 20px; width: 428px; text-align: left; }
-  header nav a:first-of-type { margin-left: 0;}
+  header nav a:first-of-type { margin-left: 0; }
   img { width: 100%; }
 }
 
-@media only screen and (min-width: 320px) and (max-width: 649px) {
+@media (min-width: 320px) and (max-width: 649px) {
   .span4, .span8, .span10, .span12 { width: 100%; }
   a { word-wrap: break-word;}
   nav { float: left; padding-top: 20px; }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -508,13 +508,12 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
 /* Media Queries */
 /* ----------------------------------------------------------------------------------- */
 
-@media only screen and (min-width: 768px) and (max-width: 959px)  {
-  li.no-mobile { display: none; }
+@media only screen and (max-width: 979px)  {
+  .no-mobile { display: none !important; }
 }
 
 @media only screen and (min-width: 650px) and (max-width: 767px) {
   .span4, .span8, .span10, .span12 { width: 100%; }
-  li.no-mobile { display: none; }
   nav { float: left; padding-top: 20px; width: 428px; text-align: left; }
   header nav a:first-of-type { margin-left: 0;}
   img { width: 100%; }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -267,7 +267,6 @@ header nav a {
   height: 150px;
   background-position: center;
   background-color: #eee;
-  background-size: 250%;
 }
 
 a.open.data:hover { color: #05d8af; border-color: #05d8af; }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -496,7 +496,7 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
 
 .category { margin-right: 8px; }
 
-#Archive .meta, #CategoryArchive .meta {
+#Archive .meta, #Category-Archive .meta {
   padding-bottom: 0;
   font-weight: 300;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,9 +17,6 @@ li img {
 
 body {
   font: 300 14px/20px "Helvetica Neue", Helvetica, Arial, sans-serif;
-  -webkit-box-sizing: border-box;
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
 }
 
 .container {
@@ -91,29 +88,10 @@ a:hover {
   box-shadow: none;
 }
 
-a.inline-link {
-  text-decoration: none;
-  color: #00c3f8;
-  border: none;
-}
-
-h1 a.inline-link:hover {
-  border-bottom: 2px solid #00c3f8;
-}
-
 a.title-link { color: #333; }
 a.title-link:hover { color: #00c3f8; }
 
 h1 a.title-link:hover { border-bottom: 2px solid #00c3f8; }
-
-a.glossary {
-  border-bottom: 1px dotted #acacac;
-  color: #333;
-}
-
-a.glossary:hover {
-  color: #acacac;
-}
 
 .inline-link.open .data, a.open .data { border-color: #05d8af; color: #05d8af; }
 .inline-link.open .government, a.open .government { border-color: #f42f71; color: #f42f71; }
@@ -187,11 +165,6 @@ small {
   padding: 0;
 }
 
-.mega-section {
-  margin-top: 140px;
-  margin-bottom: 140px;
-}
-
 .full-width {
   width: 100%;
   background-color: #f9f9f9;
@@ -203,38 +176,6 @@ small {
 
 nav {
   float: right;
-}
-
-.mega-octicon {
-  font: normal normal 32px octicons;
-  line-height: 1;
-  display: inline-block;
-  text-decoration: none;
-  -webkit-font-smoothing: antialiased;
-}
-
-.logo-invertocat {
-  float: left;
-  padding: 8px 10px 7px;
-  margin-left: -10px;
-  margin-right: -10px;
-  color: #333;
-  -webkit-transition: all 0.1s ease-in 0;
-  -moz-transition: all 0.1s ease-in 0;
-  -o-transition: all 0.1s ease-in 0;
-  transition: all 0.1s ease-in;
-  white-space: nowrap;
-}
-
-.logo-invertocat:hover {
-  border: none;
-}
-
-#top-nav .octicon-mark-github {
-  float: left;
-  width: 24px;
-  height: 25px;
-  font-size: 25px;
 }
 
 header {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -319,6 +319,9 @@ header nav a {
 
 .homepage-image {
   border-bottom: 3px solid;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
   max-width: 770px;
   height: 150px;
   background-position: center;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -122,9 +122,9 @@ small {
   color: #acacac;
 }
 
-.open .data:not(.more-stories, .title-link) { color: #05d8af; }
-.open .government:not(.more-stories, .title-link) { color: #f42f71; }
-.open .source:not(.more-stories, .title-link) { color: #00acef; }
+.open .data:not(.more-stories):not(.title-link) { color: #05d8af; }
+.open .government:not(.more-stories):not(.title-link) { color: #f42f71; }
+.open .source:not(.more-stories):not(.title-link) { color: #00acef; }
 
 .data { color: #05d8af; }
 .government { color: #f42f71; }


### PR DESCRIPTION
Overview:
1. Fixed footer links with low resolutions; now the footer links don't overlap anymore
2. Fixed `:not` selector
3. Simplified media queries
4. Removed zooming from homepage-image
5. Removed many unused selectors
