### PR TITLE
Fix up the organization JSON feed

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -219,7 +219,7 @@ tagline: 'Stories of <a href="/categories/#open-source" class="open source" titl
 analytics_account: "UA-3769691-28"
 
 # build settings
-exclude: ["script", "vendor", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "*.json"]
+exclude: ["script", "vendor", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "package.json"]
 root: "/"
 paginate: 6
 markdown: kramdown

--- a/organizations.json
+++ b/organizations.json
@@ -1,8 +1,4 @@
 ---
 layout: none
 ---
-{ {% for type_hash in site.organizations %}
-"{{ type_hash[0] }}": [
-  {% for org in type_hash[1] %}"{{ org }}"{% if forloop.rindex0 > 0 %}, {% endif %}{% endfor %}
-  ]{% if forloop.rindex0 > 0 %}, {% endif %}
-{% endfor %}}
+{{ site.organizations | jsonify }}


### PR DESCRIPTION
Move to the new `jsonify` Jekyll filter for less error prone JSON generation.

Also, looks like `organizations.json` accidentally got ignored via 575f06d727edb14efad2a196da3c1ade55244566.
