### PR TITLE
Added Code for Africa

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -206,3 +206,4 @@ Civic Hackers:
   - KoelnAPI
   - okfirl
   - openstate
+  - codeforafrica


### PR DESCRIPTION
Code for Africa is a citizen-focused, demand-driven movement that seeks to empower ordinary people to hold those in power to account.

![Code for Africa](https://0.gravatar.com/avatar/d917aa3f120fe384c70da639ddf955fa?d=https%3A%2F%2Fidenticons.github.com%2Fe8ae73b141d8729e81fe4c473ac29d50.png&r=x&s=200)
**Website**: http://www.codeforafrica.org
**Twitter**: [@Code4Africa ](http://twitter.com/Code4Africa)
**Github**: @CodeForAfrica 
