### PR TITLE
Adds datauy from Uruguay to organizations.

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -128,6 +128,9 @@ International:
   - ogpl
   - rOpenGov
 
+Uruguay:
+  - datauy
+
 U.S. States:
   - agrc
   - nysenate

--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -128,9 +128,6 @@ International:
   - ogpl
   - rOpenGov
 
-Uruguay:
-  - datauy
-
 U.S. States:
   - agrc
   - nysenate
@@ -210,3 +207,4 @@ Civic Hackers:
   - okfirl
   - openstate
   - codeforafrica
+  - datauy


### PR DESCRIPTION
Website: www.datauy.org
