### PR TITLE
"Crowd source" is a stilted way to refer to a group of contributors in "A Modern Approach to Open Data"

### DIFF
--- a/_posts/2013-10-01-modern-approach-to-open-data.md
+++ b/_posts/2013-10-01-modern-approach-to-open-data.md
@@ -2,18 +2,18 @@
 layout: story
 author: Ben Balter, GitHub
 title: A Modern Approach to Open Data
-description: Developers from the Sunlight Foundation, GovTrack, and the New York Times decided to stop each building the same basic tools over and over, and start building an open data platform they could share.
+description: Developers from the Sunlight Foundation, GovTrack, and The New York Times decided to stop each building the same basic tools over and over, and start building an open data platform they could share.
 image: /images/unitedstates.png
 category: open data
 ---
 
 Traditionally, consuming open government data required building and curating many custom tools and wrappers to convert the data from the form it's exposed in to something more immediately consumable by civic hackers, watchdog groups, and the general public. Developers haphazardly wrote small scripts as one-off efforts and threw them away, or left their solutions buried inside larger infrastructure, reinventing the wheel with each new transparency initiative.
 
-Developers from the [Sunlight Foundation](http://sunlightfoundation.com/), [GovTrack](http://www.govtrack.us/), and the New York Times, however, decided to join forces and break from tradition when they reached out to other civic-minded developers and "decided to stop each building the same basic tools over and over, and start building a foundation [they] could share."
+Developers from the [Sunlight Foundation](http://sunlightfoundation.com/), [GovTrack](http://www.govtrack.us/), and _The New York Times_, however, decided to join forces and break from tradition when they reached out to other civic-minded developers and "decided to stop each building the same basic tools over and over, and start building a foundation [they] could share."
 
 They set up shop at [github.com/unitedstates](https://github.com/unitedstates) and got to work collaboratively curating the [who](https://github.com/unitedstates/congress-legislators/) and [what](https://github.com/unitedstates/congress) of Congress. Using a mix of automation and brute force they quietly assembled the "basic information from all over the government -- THOMAS.gov, the House and Senate, the Congressional Bioguide, GPO's FDSys, and others -- that everyone needs to report, analyze, or build nearly anything to do with Congress."
 
-But it didn't end there. Their efforts were about more than just code — [it was about making government transparency a group effort](http://sunlightfoundation.com/blog/2013/08/20/a-modern-approach-to-open-data/). A community began to emerge around the shared challenges of government data. Subject matter experts shed light on [the nuances of government datasets](https://github.com/unitedstates/congress-legislators/issues/2), and crowd source began to [fill in the gaps of missing data](https://github.com/unitedstates/congress-legislators/pull/39) while others still took to building tools to [analyze and visualize those very datasets](http://news.yahoo.com/senate-budget-amendments-interactive-track-changes-153640966.html).
+But it didn't end there. Their efforts were about more than just code — [it was about making government transparency a group effort](http://sunlightfoundation.com/blog/2013/08/20/a-modern-approach-to-open-data/). A community began to emerge around the shared challenges of government data. Subject matter experts shed light on [the nuances of government datasets](https://github.com/unitedstates/congress-legislators/issues/2), and crowd sourced efforts began to [fill in the gaps of missing data](https://github.com/unitedstates/congress-legislators/pull/39) while others still took to building tools to [analyze and visualize those very datasets](http://news.yahoo.com/senate-budget-amendments-interactive-track-changes-153640966.html).
 
 What made these open data efforts such a success?
 


### PR DESCRIPTION
"crowd source" is a verb, so using it to label a group of people makes the sentence a little awkward.

"crowd sourced efforts" attempts to deliver the same drive and people but without rewriting the entire sentence fragment in a passive voice.
