### PR TITLE
Remove the reference to sitemap.xsl

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,7 +2,6 @@
 layout: none
 ---
 <?xml version="1.0" encoding="UTF-8"?>
-<?xml-stylesheet type="text/xsl" href="/sitemap.xsl"?>
 <urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>{{ site.url }}/</loc>


### PR DESCRIPTION
This xsl file doesn't exist so Chrome just renders a blank page when you visit sitemap.xml.
