### PR TITLE
Added PROCERGS

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -14,6 +14,7 @@ Brazil:
   - gabinetedigital
   - plonegovbr
   - dadosgovbr
+  - PROCERGS
 
 Canada:
   - cityofgreatersudbury


### PR DESCRIPTION
PROCERGS is the data processing company for the brazilian state Rio Grande do Sul.

We are currently working on a few open source projects, one of which is already available on GitHub.
