### PR TITLE
Remove gsa-ocsit

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -94,7 +94,6 @@ United States:
   - fcc
   - foreignassistance
   - gsa
-  - gsa-ocsit
   - hhs
   - historyatstate
   - hpc


### PR DESCRIPTION
The GitHub organization appears to have been removed
