### PR TITLE
Make the instructions more welcoming to those with non-government emails

### DIFF
--- a/index.html
+++ b/index.html
@@ -92,7 +92,7 @@ org_count: 60
       <div class="span4">
         <h2>Connect</h2>
         <ul class="no-style-list">
-          <li>We've started a Government organization on GitHub so that users can connect, share best practices and learn from each other. To join, simply ensure your government email address is verified and associated with your account, and you should <a href="https://government-community.githubapp.com/">automatically be granted access</a>.</li>
+          <li>We've started a Government organization on GitHub so that users can connect, share best practices and learn from each other. To join, simply ensure your government email address is verified and associated with your account, and you should <a href="https://government-community.githubapp.com/">automatically be granted access</a>. If you don't have a government email address, but are interested please <a href="mailto:government@github.com">contact us</a>.</li>
         </ul>
       </div>
     </div> <!-- class="row-fluid section" -->


### PR DESCRIPTION
There are a number of influential and interested individuals who don't have government-issued email addresses e.g. retirees, collaborators in academia, concerned citizens, etc. I'd like to propose stating that we're _not_ excluding them and making joining the [GitHub for Government](https://github.com/government) community a little more welcoming to those people.

Should the requests go to government@github.com, or should they be vetted openly in a public-facing Issue under the [github.com/government](https://github.com/government) organization?

I'm sure the verbiage can be improved. Pull requests welcome.

/cc @github/government 
