### PR TITLE
Add Mexico and UdeG (Universidad de Guadalajara)

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -43,6 +43,9 @@ Germany:
   - gbv
   - lobid
 
+Mexico:
+  - UdeG
+
 New Zealand:
   - linz
   - CanterburyRegionalCouncil


### PR DESCRIPTION
The UdeG is the Universidad de Guadalajara from Guadalajara, Jalisco, Mexico and use GitHub to colaborate in open source development.
