### PR TITLE
Change skip to content to "supports"

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -118,7 +118,7 @@ data:
         support:  Supports
         comments:
       - criterion: "(o) A method shall be provided that permits users to skip repetitive navigation links."
-        support:  Does not support
+        support:  Supports
         comments:
       - criterion: "(p) When a timed response is required, the user shall be alerted and given sufficient time to indicate more time is required."
         support:  Not applicable


### PR DESCRIPTION
`<a href="#start-of-content" class="accessibility-aid js-skip-to-content">Skip to content</a>` and `<div id="start-of-content" class="accessibility-aid"></div>` were added to GitHub.com (and soon GitHub Enterprise), + some CSS/javascript to hide the link from non-screen readers and and properly set focus on click.

Props @muan!

/cc @github/accessibility 
