### PR TITLE
Update organizations.yml

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -52,7 +52,7 @@ Norway:
   - difi
   - kartverket
 
-Philippines
+Philippines:
   - govph
 
 Puerto Rico:

--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -52,6 +52,9 @@ Norway:
   - difi
   - kartverket
 
+Philippines
+  - govph
+
 Puerto Rico:
   - commonwealth-of-puerto-rico
 


### PR DESCRIPTION
Adding the Phillippine national government's github organization, govph to this list. GOVPH is managed and maintained by the Office of the President, under the Presidential Communications Development and Strategic Planning Office.
