### PR TITLE
Add the organization Space Advocates

### DIFF
--- a/_data/organizations.yml
+++ b/_data/organizations.yml
@@ -235,3 +235,4 @@ Civic Hackers:
   - votinginfoproject
   - postcode
   - datauy
+  - SpaceAdvocates


### PR DESCRIPTION
Space Advocates is a nonprofit space advocacy organization tasked with promoting space literacy and legislation through citizen engagement.

We are behind the viral campaign Penny4NASA on Facebook and Twitter, which strives to increase NASA’s funding to 1% by encouraging popular support for NASA through education and outreach.
