### PR TITLE
Change /community to a list 

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -302,6 +302,12 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
 
 /* Organizations Section */
 
+.table td {vertical-align: middle;}
+
+.community-avatar {
+  width: 45px;
+}
+
 #orgs {
   position: relative;
   height: 365px;

--- a/community.md
+++ b/community.md
@@ -7,16 +7,20 @@ permalink: /community/
 <div class="container">
   <div class="row-fluid">
     <div class="span8">
-    {% for type_hash in site.data.organizations %}
-    <div class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}"><p>{{ type_hash[0] }}</p></div>
-      {% for org in type_hash[1] %}
-        <div class="organization">
-          <a href="https://github.com/{{ org }}" title="{{ org }}">
-            <img class="avatar" src="https://github.com/{{ org }}.png" width="80" height="80" alt="{{ org }}">
-          </a>
-        </div>
-      {% endfor %}
-    {% endfor %}
+      <table class="table table-bordered">
+        <tr><th>Avatar</th><th>Account</th><th>Country / Group</th></tr>
+          {% for type_hash in site.data.organizations %}
+            {% for org in type_hash[1] %}
+            <tr>
+              <td class="community-avatar">
+                <img src="http://www.github.com/{{org}}.png" width="40px">
+              </td>
+              <td><a href="https://github.com/{{ org }}" title="{{ org }}">{{ org }}</a>
+              </td><td>{{ type_hash[0] }}</td>
+            </tr>
+           {% endfor %}
+          {% endfor %}
+        </table>
     </div>
   </div>
 


### PR DESCRIPTION
This turns the community page into a list. We have so many now that the avatar wall isn't that helpful. I don't even think we need a 'switch to avatar wall view' option, I think we can just go with list from this point forward. This is a super simple Bootstrap list implementation of our data.

It might be nice to have the list better organized (other than just country/group) but this is the easiest to ship version. Maybe later we want to think about getting more info in the data. 

![screen shot 2014-05-21 at 9 38 58 pm](https://cloud.githubusercontent.com/assets/1305617/3045878/0fe95456-e122-11e3-8dfc-73bca53f0e6c.png)
