### PR TITLE
Break up Civic Hackers, Script CFA Updating

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -23,11 +23,6 @@ Civic Hackers:
   - mysociety
   - npp
   - odhk
-  - okfde
-  - okfegypt
-  - okfn
-  - okfn-brasil
-  - okfngr
   - open-city
   - openaustralia
   - opengovfoundation
@@ -49,3 +44,20 @@ Civic Hackers:
   - unitedstates
   - votinginfoproject
   - yourmapper
+
+Code For America:
+  - civicdata
+  - codeforasheville
+  - codeforseattle
+  - codeforthecaribbean
+  - codefortulsa
+  - openchattanooga
+  - openjc
+  - opensaltlake
+
+Open Knowledge Foundation:
+  - okfde
+  - okfegypt
+  - okfn
+  - okfn-brasil
+  - okfngr

--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -5,7 +5,6 @@ Civic Hackers:
   - civio
   - CodeandoMexico
   - codeforafrica
-  - codeforamerica
   - codeforeurope
   - codeforjapan
   - codefortomorrow
@@ -47,6 +46,7 @@ Civic Hackers:
 
 Code For America:
   - civicdata
+  - codeforamerica
   - codeforasheville
   - codeforseattle
   - codeforthecaribbean

--- a/community.md
+++ b/community.md
@@ -24,6 +24,9 @@ permalink: /community/
     <div class="span8">
       <h2>Civic Hackers</h2>
       {% for type_hash in site.data.civic_hackers %}
+        {% unless type_hash[0] == "Civic Hackers" %}
+        <div class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}"><p>{{ type_hash[0] }}</p></div>
+        {% endunless %}
         {% for org in type_hash[1] %}
           <div class="organization">
             <a href="https://github.com/{{ org }}" title="{{ org }}">

--- a/script/fetch-cfa
+++ b/script/fetch-cfa
@@ -1,0 +1,32 @@
+#!/usr/bin/env ruby
+
+#fetches list of CFA brigades from the CFA API, and outputs merged list to command line
+
+require "open-uri"
+require "json"
+require "yaml"
+
+org_file = YAML.load_file "./_data/civic_hackers.yml"
+data = JSON.parse open("http://codeforamerica.org/api/organizations").read
+
+orgs = []
+data["objects"].each do |org|
+  org["current_projects"].each do |project|
+    orgs.push project["github_details"]["owner"]["login"]
+  end
+end
+
+orgs.uniq!
+
+orgs.each do |org|
+  org_file["Code For America"].push(org.downcase) unless org_file["Code For America"].include?(org.downcase)
+end
+
+output = {
+  "Code For America" => org_file["Code For America"].uniq.sort do
+      |a,b| a.upcase <=> b.upcase
+  end
+}
+
+puts "To be pasted into _data/civic_hackers.yml"
+puts output.to_yaml


### PR DESCRIPTION
This pull request
1. Breaks up the long list of "Civic Hackers" with groups for Code for America and Open Knowledge Foundation
2. Adds a small `script/fetch-cfa` to update the list of known brigade orgs via the CfA API

Questions:
1. Any other large groupings worth breaking up?
2. Are these all the brigades? Are we using the API properly?

/cc @ashleymmeyers for the excellent idea (and @jlord because CFA :smile:)
