### PR TITLE
Add UK's Department of Energy and Climate Change

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -243,6 +243,7 @@ United Kingdom:
   - CarersBeta
   - companieshouse
   - datagovuk
+  - decc
   - DevonCountyCouncil
   - dfid
   - digital-preservation


### PR DESCRIPTION
Adds the UK's [Department of Energy & Climate Change](https://www.gov.uk/government/organisations/department-of-energy-climate-change).

/cc @benbalter 
