### PR TITLE
Show Community in a Table

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -22,7 +22,6 @@
       </div>
     </footer>
 
-  <script src="/assets/js/jquery.min.js"></script>
   <script src="/assets/js/bootstrap.min.js"></script>
   </body>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -9,6 +9,7 @@
   <link rel="shortcut icon" href="/assets/img/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/assets/css/style.css">
   <link rel="stylesheet" href="/assets/css/icons.css">
+  <script src="/assets/js/jquery.min.js"></script>
   <!--[if lt IE 9]>
     <script src="/assets/js/html5shiv.js"></script>
     <script src="/assets/js/respond.min.js"></script>

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -44,17 +44,21 @@
         $('.searchable tr').filter(function () {
             return rex.test($(this).text());
         }).show();
+        console.log("gov", $('.govtable tr:visible').length)
+        console.log("civ", $('.civictable tr:visible').length)
 
         if ($('.govtable tr:visible').length === 0) {
           $('.govtable.no-matches').show();
         } else {
           $('.govtable.no-matches').hide();
+          $('.govtable.table-header').show();
         };
 
         if ($('.civictable tr:visible').length === 0) {
           $('.civictable.no-matches').show();
         } else {
           $('.civictable.no-matches').hide();
+          $('.civictable.table-header').show();
         };
       })
     }(jQuery));

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -38,27 +38,27 @@
 <script>
   $(document).ready(function () {
     (function ($) {
-        $('#filter').keyup(function () {
-            var rex = new RegExp($(this).val(), 'i');
-            $('.searchable tr').hide();
-            $('.searchable tr').filter(function () {
-                return rex.test($(this).text());
-            }).show();
+      $('#filter').keyup(function () {
+        var rex = new RegExp($(this).val(), 'i');
+        $('.searchable tr').hide();
+        $('.searchable tr').filter(function () {
+            return rex.test($(this).text());
+        }).show();
 
-            if ($('.govtable tr:visible').length === 0) {
-              $('.govtable.no-matches').show();
-            } else {
-              $('.govtable.no-matches').hide();
-            };
+        if ($('.govtable tr:visible').length === 0) {
+          $('.govtable.no-matches').show();
+        } else {
+          $('.govtable.no-matches').hide();
+        };
 
-            if ($('.civictable tr:visible').length === 0) {
-              $('.civictable.no-matches').show();
-            } else {
-              $('.civictable.no-matches').hide();
-            };
-        })
+        if ($('.civictable tr:visible').length === 0) {
+          $('.civictable.no-matches').show();
+        } else {
+          $('.civictable.no-matches').hide();
+        };
+      })
     }(jQuery));
-});
+  });
 </script>
 
 {% include footer.html %}

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -35,4 +35,18 @@
     </div>
   </div>
 
+<script>
+  $(document).ready(function () {
+    (function ($) {
+        $('#filter').keyup(function () {
+            var rex = new RegExp($(this).val(), 'i');
+            $('.searchable tr').hide();
+            $('.searchable tr').filter(function () {
+                return rex.test($(this).text());
+            }).show();
+        })
+    }(jQuery));
+});
+</script>
+
 {% include footer.html %}

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -44,8 +44,6 @@
         $('.searchable tr').filter(function () {
             return rex.test($(this).text());
         }).show();
-        console.log("gov", $('.govtable tr:visible').length)
-        console.log("civ", $('.civictable tr:visible').length)
 
         if ($('.govtable tr:visible').length === 0) {
           $('.govtable.no-matches').show();

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -42,21 +42,20 @@
             var rex = new RegExp($(this).val(), 'i');
             $('.searchable tr').hide();
             $('.searchable tr').filter(function () {
-                // console.log($('.searchable tr:visible').length)
                 return rex.test($(this).text());
             }).show();
 
             if ($('.govtable tr:visible').length === 0) {
-              $('.govtable.no-matches').show()
+              $('.govtable.no-matches').show();
             } else {
-              $('.govtable.no-matches').hide()
-            }
+              $('.govtable.no-matches').hide();
+            };
 
             if ($('.civictable tr:visible').length === 0) {
-              $('.civictable.no-matches').show()
+              $('.civictable.no-matches').show();
             } else {
-              $('.civictable.no-matches').hide()
-            }
+              $('.civictable.no-matches').hide();
+            };
         })
     }(jQuery));
 });

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -42,8 +42,21 @@
             var rex = new RegExp($(this).val(), 'i');
             $('.searchable tr').hide();
             $('.searchable tr').filter(function () {
+                // console.log($('.searchable tr:visible').length)
                 return rex.test($(this).text());
             }).show();
+
+            if ($('.govtable tr:visible').length === 0) {
+              $('.govtable.no-matches').show()
+            } else {
+              $('.govtable.no-matches').hide()
+            }
+
+            if ($('.civictable tr:visible').length === 0) {
+              $('.civictable.no-matches').show()
+            } else {
+              $('.civictable.no-matches').hide()
+            }
         })
     }(jQuery));
 });

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -357,7 +357,7 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
   width: 80px;
 }
 
-.type-block {
+/*.type-block {
   float: left;
   width: 80px;
   height: 80px;
@@ -366,11 +366,25 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
   text-align: center;
   margin: 5px 5px 5px 0;
   color: #fff;
+}*/
+
+.table td {
+
 }
 
-.type-block p {
-  margin: 14px 7px;
+.type-block + tr td {
+  border-color: #fff;
 }
+
+.type-block td {
+  /*border-bottom: 1px solid #eee;*/
+  background-color: #fafafa;
+  border-color: #fff;
+}
+
+/*.type-block p {
+  margin: 14px 7px;
+}*/
 
 .organization > a > img {
   vertical-align: middle;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -74,20 +74,6 @@ a:hover {
   box-shadow: none;
 }
 
-.table td, .table th {
-  vertical-align: middle;
-}
-
-#filter {
-  border-radius: 0;
-  border: none;
-  border-bottom: 2px solid #00c3f8;
-  box-shadow: none;
-  padding-left: 0;
-}
-
-.search-section { padding-bottom: 20px; }
-
 a.title-link { color: #333; }
 a.title-link:hover { color: #00c3f8; }
 
@@ -352,43 +338,10 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
   width: 80px;
 }
 
-.avatar {
-  height: 80px;
-  width: 80px;
-}
-
-/*.type-block {
-  float: left;
-  width: 80px;
-  height: 80px;
-  background-color: #00c3f8;
-  vertical-align: middle;
-  text-align: center;
-  margin: 5px 5px 5px 0;
-  color: #fff;
-}*/
-
-.table td {
-
-}
-
-.type-block + tr td {
-  border-color: #fff;
-}
-
-.type-block td {
-  /*border-bottom: 1px solid #eee;*/
-  background-color: #fafafa;
-  border-color: #fff;
-}
-
-/*.type-block p {
-  margin: 14px 7px;
-}*/
-
 .organization > a > img {
   vertical-align: middle;
 }
+
 
 /* Single Story Page */
 /* ----------------------------------------------------------------------------------- */
@@ -424,6 +377,42 @@ a.open.source:hover { color: #00acef; border-color: #00acef; }
 #markdown-toc {
   padding-bottom: 30px;
 }
+
+.type-block + tr td {
+  border-color: #fff;
+}
+
+.type-block td {
+  background-color: #fafafa;
+  border-color: #fff;
+}
+
+.table-header th {
+  border-bottom: 1px solid #ddd;
+}
+
+.table td, .table th {
+  vertical-align: middle;
+}
+
+.table td p {
+  margin: 0;
+}
+
+.dim-affiliation {
+  color: #ccc;
+  font-weight: 200;
+}
+
+#filter {
+  border-radius: 0;
+  border: none;
+  border-bottom: 2px solid #00c3f8;
+  box-shadow: none;
+  padding-left: 0;
+}
+
+.search-section { padding-bottom: 20px; }
 
 
 /* archive page */

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -74,6 +74,10 @@ a:hover {
   box-shadow: none;
 }
 
+.table td, .table th {
+  vertical-align: middle;
+}
+
 a.title-link { color: #333; }
 a.title-link:hover { color: #00c3f8; }
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -78,6 +78,16 @@ a:hover {
   vertical-align: middle;
 }
 
+#filter {
+  border-radius: 0;
+  border: none;
+  border-bottom: 2px solid #00c3f8;
+  box-shadow: none;
+  padding-left: 0;
+}
+
+.search-section { padding-bottom: 20px; }
+
 a.title-link { color: #333; }
 a.title-link:hover { color: #00c3f8; }
 

--- a/community.md
+++ b/community.md
@@ -13,11 +13,10 @@ permalink: /community/
       <h6 class="govtable no-matches" style="display: none;">No matches.</h6>
         <table class="govtable table">
           <tbody class="searchable">
-          <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+          <tr class="table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
           {% for type_hash in site.data.governments %}
           <tr class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}">
-            <!-- <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td> -->
-            <td></td><td></td><td></td>
+            <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td>
           </tr>
           {% for org in type_hash[1] %}
             <tr>
@@ -29,8 +28,7 @@ permalink: /community/
                 <p>{{ org }}</p>
               </td>
               <td>
-                <!-- <p style="color: #ccc; font-weight: 200;">{{ type_hash[0] }}</p> -->
-                <p>{{ type_hash[0] }}</p>
+                <p class="dim-affiliation">{{ type_hash[0] }}</p>
               </td>
             </tr>
           {% endfor %}

--- a/community.md
+++ b/community.md
@@ -15,6 +15,10 @@ permalink: /community/
           <tbody class="searchable">
           <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
           {% for type_hash in site.data.governments %}
+          <tr class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}">
+            <!-- <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td> -->
+            <td></td><td></td><td></td>
+          </tr>
           {% for org in type_hash[1] %}
             <tr>
               <td>
@@ -25,6 +29,7 @@ permalink: /community/
                 <p>{{ org }}</p>
               </td>
               <td>
+                <!-- <p style="color: #ccc; font-weight: 200;">{{ type_hash[0] }}</p> -->
                 <p>{{ type_hash[0] }}</p>
               </td>
             </tr>
@@ -48,6 +53,7 @@ permalink: /community/
 
         {% endunless %}
         {% for org in type_hash[1] %}
+
           <tr>
             <td>
               <a href="https://github.com/{{ org }}" title="{{ org }}">

--- a/community.md
+++ b/community.md
@@ -7,8 +7,8 @@ permalink: /community/
 <div class="container">
   <div class="row-fluid">
     <div class="span8">
-    <input id="filter" type="text" class="form-control" placeholder="Search for...">
-    <h5>Search all organizations or jump to <a href="#civichackers">Civic Hackers</a> list.</h5>
+    <div class="search-section">
+    <h5><input id="filter" type="text" class="form-control" placeholder="Type to search..."> or jump to <a href="#civichackers">Civic Hackers</a> list.</h5></div>
       <h2 id="governments">Governments</h2>
         <table class="table">
           <tbody class="searchable">

--- a/community.md
+++ b/community.md
@@ -13,7 +13,7 @@ permalink: /community/
       <h6 class="govtable no-matches" style="display: none;">No matches.</h6>
         <table class="govtable table">
           <tbody class="searchable">
-            <tr class="table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+            <tr class="govtable table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
             {% for type_hash in site.data.governments %}
             <tr class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}">
               <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td>
@@ -25,7 +25,7 @@ permalink: /community/
                 <img src="https://github.com/{{ org }}.png" width="40" height="40" alt="{{ org }}"></a>
               </td>
               <td>
-                <p>{{ org }}</p>
+                <p><a href="https://github.com/{{ org }}" title="{{ org }}">{{ org }}</a></p>
               </td>
               <td>
                 <p class="dim-affiliation">{{ type_hash[0] }}</p>
@@ -45,7 +45,7 @@ permalink: /community/
       <h6 class="civictable no-matches" style="display: none;">No matches.</h6>
       <table class="civictable table">
         <tbody class="searchable">
-          <tr class="table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+          <tr class="civictable table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
           {% for type_hash in site.data.civic_hackers %}
           {% unless type_hash[0] == "Civic Hackers" %}
           {% endunless %}
@@ -59,7 +59,7 @@ permalink: /community/
                 <img src="https://github.com/{{ org }}.png" width="40" height="40" alt="{{ org }}"></a>
               </td>
               <td>
-                <p>{{ org }}</p>
+                <p><a href="https://github.com/{{ org }}" title="{{ org }}">{{ org }}</a></p>
               </td>
               <td>
                 <p class="dim-affiliation">{{ type_hash[0] }}</p>

--- a/community.md
+++ b/community.md
@@ -13,12 +13,12 @@ permalink: /community/
       <h6 class="govtable no-matches" style="display: none;">No matches.</h6>
         <table class="govtable table">
           <tbody class="searchable">
-          <tr class="table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
-          {% for type_hash in site.data.governments %}
-          <tr class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}">
-            <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td>
-          </tr>
-          {% for org in type_hash[1] %}
+            <tr class="table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+            {% for type_hash in site.data.governments %}
+            <tr class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}">
+              <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td>
+            </tr>
+            {% for org in type_hash[1] %}
             <tr>
               <td>
                 <a href="https://github.com/{{ org }}" title="{{ org }}">
@@ -45,27 +45,28 @@ permalink: /community/
       <h6 class="civictable no-matches" style="display: none;">No matches.</h6>
       <table class="civictable table">
         <tbody class="searchable">
-        <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
-        {% for type_hash in site.data.civic_hackers %}
-        {% unless type_hash[0] == "Civic Hackers" %}
-
-        {% endunless %}
-        {% for org in type_hash[1] %}
-
-          <tr>
-            <td>
-              <a href="https://github.com/{{ org }}" title="{{ org }}">
-              <img src="https://github.com/{{ org }}.png" width="40" height="40" alt="{{ org }}"></a>
-            </td>
-            <td>
-              <p>{{ org }}</p>
-            </td>
-            <td>
-              <p>{{ type_hash[0] }}</p>
-            </td>
-          </tr>
-        {% endfor %}
-        {% endfor %}
+          <tr class="table-header"><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+          {% for type_hash in site.data.civic_hackers %}
+          {% unless type_hash[0] == "Civic Hackers" %}
+          {% endunless %}
+          <tr class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}">
+            <td><h3>{{ type_hash[0] }}</h3></td><td></td><td></td>
+            </tr>
+            {% for org in type_hash[1] %}
+            <tr>
+              <td>
+                <a href="https://github.com/{{ org }}" title="{{ org }}">
+                <img src="https://github.com/{{ org }}.png" width="40" height="40" alt="{{ org }}"></a>
+              </td>
+              <td>
+                <p>{{ org }}</p>
+              </td>
+              <td>
+                <p class="dim-affiliation">{{ type_hash[0] }}</p>
+              </td>
+            </tr>
+            {% endfor %}
+          {% endfor %}
         </tbody>
       </table>
     </div>

--- a/community.md
+++ b/community.md
@@ -7,10 +7,11 @@ permalink: /community/
 <div class="container">
   <div class="row-fluid">
     <div class="span8">
-    <h5>Jump to <a href="#civichackers">Civic Hackers</a> list</h5>
+    <input id="filter" type="text" class="form-control" placeholder="Search for...">
+    <h5>Search all organizations or jump to <a href="#civichackers">Civic Hackers</a> list.</h5>
       <h2 id="governments">Governments</h2>
-
         <table class="table">
+          <tbody class="searchable">
           <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
           {% for type_hash in site.data.governments %}
           {% for org in type_hash[1] %}
@@ -28,15 +29,17 @@ permalink: /community/
             </tr>
           {% endfor %}
           {% endfor %}
+        </tbody>
       </table>
     </div>
   </div>
 
   <div class="row-fluid">
     <div class="span8">
-      <h5>Jump to <a href="#civichackers">Governments</a> list</h5>
+      <h5>Jump to <a href="#governments">Governments</a> list.</h5>
       <h2 id="civichackers">Civic Hackers</h2>
       <table class="table">
+        <tbody class="searchable">
         <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
         {% for type_hash in site.data.civic_hackers %}
         {% unless type_hash[0] == "Civic Hackers" %}
@@ -56,7 +59,8 @@ permalink: /community/
             </td>
           </tr>
         {% endfor %}
-      {% endfor %}
+        {% endfor %}
+        </tbody>
       </table>
     </div>
   </div>

--- a/community.md
+++ b/community.md
@@ -8,33 +8,56 @@ permalink: /community/
   <div class="row-fluid">
     <div class="span8">
       <h2>Governments</h2>
+
+        <table class="table">
+        <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
       {% for type_hash in site.data.governments %}
-      <div class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}"><p>{{ type_hash[0] }}</p></div>
-        {% for org in type_hash[1] %}
-          <div class="organization">
-            <a href="https://github.com/{{ org }}" title="{{ org }}">
-              <img class="avatar" src="https://github.com/{{ org }}.png" width="80" height="80" alt="{{ org }}">
-            </a>
-          </div>
-        {% endfor %}
+
+            {% for org in type_hash[1] %}
+            <tr>
+              <td>
+                <a href="https://github.com/{{ org }}" title="{{ org }}">
+                <img src="https://github.com/{{ org }}.png" width="40" height="40" alt="{{ org }}"></a>
+              </td>
+              <td>
+                <p>{{ org }}</p>
+              </td>
+              <td>
+                <p>{{ type_hash[0] }}</p>
+              </td>
+            </tr>
+            {% endfor %}
+
+
       {% endfor %}
+      </table>
     </div>
   </div>
   <div class="row-fluid">
     <div class="span8">
       <h2>Civic Hackers</h2>
+      <table class="table">
+      <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
       {% for type_hash in site.data.civic_hackers %}
         {% unless type_hash[0] == "Civic Hackers" %}
-        <div class="type-block" id="{{ type_hash[0] | downcase | replace: ' ','_' }}"><p>{{ type_hash[0] }}</p></div>
+
         {% endunless %}
         {% for org in type_hash[1] %}
-          <div class="organization">
-            <a href="https://github.com/{{ org }}" title="{{ org }}">
-              <img class="avatar" src="https://github.com/{{ org }}.png" width="80" height="80" alt="{{ org }}">
-            </a>
-          </div>
+          <tr>
+            <td>
+              <a href="https://github.com/{{ org }}" title="{{ org }}">
+              <img src="https://github.com/{{ org }}.png" width="40" height="40" alt="{{ org }}"></a>
+            </td>
+            <td>
+              <p>{{ org }}</p>
+            </td>
+            <td>
+              <p>{{ type_hash[0] }}</p>
+            </td>
+          </tr>
         {% endfor %}
       {% endfor %}
+      </table>
     </div>
   </div>
 

--- a/community.md
+++ b/community.md
@@ -4,13 +4,14 @@ layout: support-page
 description: Government agencies at the national, state, and local level use GitHub to share and collaborate. If you don't see your organization on this list, follow the instructions below to add it!
 permalink: /community/
 ---
-<div class="container">
+<div id="to-top" class="container">
   <div class="row-fluid">
     <div class="span8">
     <div class="search-section">
     <h5><input id="filter" type="text" class="form-control" placeholder="Type to search..."> or jump to <a href="#civichackers">Civic Hackers</a> list.</h5></div>
       <h2 id="governments">Governments</h2>
-        <table class="table">
+      <h6 class="govtable no-matches" style="display: none;">No matches.</h6>
+        <table class="govtable table">
           <tbody class="searchable">
           <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
           {% for type_hash in site.data.governments %}
@@ -36,9 +37,10 @@ permalink: /community/
 
   <div class="row-fluid">
     <div class="span8">
-      <h5>Jump to <a href="#governments">Governments</a> list.</h5>
-      <h2 id="civichackers">Civic Hackers</h2>
-      <table class="table">
+      <h5 id="civichackers" class="search-section">Jump to <a href="#to-top">top</a> or <a href="#governments">Governments</a> list.</h5>
+      <h2>Civic Hackers</h2>
+      <h6 class="civictable no-matches" style="display: none;">No matches.</h6>
+      <table class="civictable table">
         <tbody class="searchable">
         <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
         {% for type_hash in site.data.civic_hackers %}

--- a/community.md
+++ b/community.md
@@ -7,13 +7,13 @@ permalink: /community/
 <div class="container">
   <div class="row-fluid">
     <div class="span8">
-      <h2>Governments</h2>
+    <h5>Jump to <a href="#civichackers">Civic Hackers</a> list</h5>
+      <h2 id="governments">Governments</h2>
 
         <table class="table">
-        <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
-      {% for type_hash in site.data.governments %}
-
-            {% for org in type_hash[1] %}
+          <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+          {% for type_hash in site.data.governments %}
+          {% for org in type_hash[1] %}
             <tr>
               <td>
                 <a href="https://github.com/{{ org }}" title="{{ org }}">
@@ -26,19 +26,19 @@ permalink: /community/
                 <p>{{ type_hash[0] }}</p>
               </td>
             </tr>
-            {% endfor %}
-
-
-      {% endfor %}
+          {% endfor %}
+          {% endfor %}
       </table>
     </div>
   </div>
+
   <div class="row-fluid">
     <div class="span8">
-      <h2>Civic Hackers</h2>
+      <h5>Jump to <a href="#civichackers">Governments</a> list</h5>
+      <h2 id="civichackers">Civic Hackers</h2>
       <table class="table">
-      <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
-      {% for type_hash in site.data.civic_hackers %}
+        <tr><th>Avatar</th><th>Account</th><th>Affiliation</th></tr>
+        {% for type_hash in site.data.civic_hackers %}
         {% unless type_hash[0] == "Civic Hackers" %}
 
         {% endunless %}


### PR DESCRIPTION
Since there are so many and the wall of avatars has become too large (a good problem!). 

**This PR**
- puts the Govs and Civic Hackers into tables.
- adds basic search
  - I found something super simple in a JSFiddle actually and added some _no matches_ logic.

**Ponderings**
- The amount of avatars we have to go and fetch is a bit redonk now. It's not the worst, but it will only get larger.
- Would it be nice to have more information about each org? This will likely require some manual work but it may be worth it for a nice dataset to have.

**WIP**
I'm going to refine some of the styles a bit more, but wanted to get the convo started.

![screen shot 2014-06-18 at 2 27 42 pm](https://cloud.githubusercontent.com/assets/1305617/3320842/ad7edce0-f72f-11e3-801b-17017ae78d3f.png)

![screen shot 2014-06-18 at 2 27 57 pm](https://cloud.githubusercontent.com/assets/1305617/3320844/b32aaaf2-f72f-11e3-97fd-fec5965bcc43.png)

![screen shot 2014-06-18 at 2 28 59 pm](https://cloud.githubusercontent.com/assets/1305617/3320845/baa61f28-f72f-11e3-829d-1f0248810c30.png)

![screen shot 2014-06-18 at 2 28 17 pm](https://cloud.githubusercontent.com/assets/1305617/3320846/bd50392a-f72f-11e3-8662-d9ddf133d231.png)
