### PR TITLE
Update governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -12,7 +12,6 @@ Australia:
   - Healthway
   - innovationgovau
   - Landgate
-  - LANL
   - museumvictoria
   - nimbusproject
   - nla
@@ -200,6 +199,7 @@ U.S. Research Labs:
   - hpde
   - idaholab
   - JGI-Bioinformatics
+  - LANL
   - LANL-Bioinformatics
   - lbl-anp
   - lblpbd


### PR DESCRIPTION
LANL is a Los Alamos National Lab, United States organization, not Australia.
