### PR TITLE
Update governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -263,6 +263,7 @@ U.S. Special District:
   - cleveland-metroparks
   - CMAP-REPOS
   - MetropolitanTransportationCommission
+  - portofsandiego
   - psrc
 
 U.S. States:
@@ -406,7 +407,6 @@ United States:
   - ozoneplatform
   - peacecorps
   - PM-Master
-  - portofsandiego
   - presidential-innovation-fellows
   - project-interoperability
   - project-open-data


### PR DESCRIPTION
portofsandiego is a special district in California, not a federal agency.
