### PR TITLE
Link to Government Showcase, fixes #293

### DIFF
--- a/index.html
+++ b/index.html
@@ -83,6 +83,7 @@ org_count: 60
     </div>
 
   </div>
+  <p><a href="https://github.com/showcases/government">See more in the Government App Showcase &rarr;</a></p>
 </div>
 
 

--- a/index.html
+++ b/index.html
@@ -83,7 +83,7 @@ org_count: 60
     </div>
 
   </div>
-  <p><a href="https://github.com/showcases/government">See more in the Government App Showcase &rarr;</a></p>
+  <p><a href="https://github.com/showcases/government">See more in the government showcase &rarr;</a></p>
 </div>
 
 


### PR DESCRIPTION
This adds a link to the Government showcases re #293 

What do you think about the copy? Should 'App' be used at all? Should 'Government __ Showcase' be lowercase?

![screen shot 2014-07-29 at 12 45 15 pm](https://cloud.githubusercontent.com/assets/1305617/3740802/54d152cc-1759-11e4-9586-4b59a06fc342.png)
