### PR TITLE
Prune featured orgs to those with at least one public repo

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -15,7 +15,6 @@ gems:
 # orgs on front page
 featured_orgs:
   - gcba
-  - agnsw
   - nla
   - GeoscienceAustralia
   - qld-gov-au
@@ -25,7 +24,6 @@ featured_orgs:
   - tisorocaba
   - ca-canada
   - mce-scarto
-  - ServiceCanada
   - wet-boew
   - e-gob
   - City-of-Helsinki
@@ -37,9 +35,7 @@ featured_orgs:
   - malmostad
   - ogdch
   - alv-ch
-  - BostonRedevelop
   - city-of-bloomington
-  - cityofboulder
   - cityofchattanooga
   - cityofnewyork
   - Honolulu
@@ -69,7 +65,6 @@ featured_orgs:
   - fda
   - gsa
   - hhs
-  - IRSgov
   - nasa
   - USDeptVeteransAffairs
   - virtual-world-framework


### PR DESCRIPTION
Quick scan of the featured and the deleted organisations don't have any public repos, so landing on them as an example feels like a dead end for now. Leaving the rest to those with at least a repo showing under their org.
