### PR TITLE
Added metno (MET Norway)

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -121,6 +121,7 @@ Norway:
   - dss-web
   - kartverket
   - KRD-KOMM-VL
+  - metno
 
 Paraguay:
   - mecpy


### PR DESCRIPTION
Added metno, the official public Git repository for open-source projects from MET Norway (the Meteorological Institute, Norway).
