### PR TITLE
Add datagovhk

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -102,6 +102,9 @@ Germany:
   - gbv
   - lobid
 
+Hong Kong:
+  - datagovhk
+
 India:
   - itschool
 
@@ -463,6 +466,7 @@ United Kingdom:
   - hmrc
   - intellectual-property-office
   - JNCC-UK
+  - kentcc
   - LambethCouncil
   - LandRegistry
   - LandRegistry-Attic
@@ -481,5 +485,3 @@ United Kingdom:
   - UKLocation
   - warwickshire
   - west-berkshire-council
-  - kentcc
-  


### PR DESCRIPTION
This pull request adds @datagovhk to the list of government organizations. They're doing some great open source work around data.gov.hk.

Going off of [the wikipedia entry](http://en.wikipedia.org/wiki/Hong_Kong), should Hong Kong be listed as it's own top-level category, or is China more appropriate?

(Ignore the @kentcc noise that came from running the alphabetization script before committing)
