### PR TITLE
adding codeforseoul

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -4,6 +4,7 @@ Civic Hackers:
   - bundestag
   - civio
   - CodeandoMexico
+  - Codeforseoul
   - codeforafrica
   - codeforeurope
   - codeforjapan


### PR DESCRIPTION
- Code for Seoul is a civic hacking group in South Korea
