### PR TITLE
Move Puerto Rico to U.S. Special Districts

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -162,9 +162,6 @@ Peru:
 Philippines:
   - govph
 
-Puerto Rico:
-  - commonwealth-of-puerto-rico
-
 Saudi Arabia:
   - SAS-NCDC
 
@@ -377,6 +374,7 @@ U.S. Special District:
   - MetropolitanTransportationCommission
   - portofsandiego
   - psrc
+  - commonwealth-of-puerto-rico
 
 U.S. States:
   - agrc


### PR DESCRIPTION
This PR moves Puerto Rico from its own country to be under the U.S. Special Districts category.

Fixes #268.
