### PR TITLE
added NYCEDC (http://edc.nyc) to the list

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -221,6 +221,7 @@ U.S. City:
   - cityoffortworth
   - CityOfGreeleyCo
   - cityofnewyork
+  - NYCEDC
   - CityOfPhiladelphia
   - CityofReno
   - CityofSanFrancisco


### PR DESCRIPTION
NYCEDC has several datasets produced on a monthly basis from the Research & Analysis team. Datasets include Labor Force & Payroll, Travel & Tourism, Demographics, Real Estate & Construction, and more.

We'll be releasing these datasets and tools in the coming months.
