### PR TITLE
Added @gsi-cyberjapan

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -132,6 +132,9 @@ Hong Kong:
 India:
   - itschool
 
+Japan:
+  - gsi-cyberjapan
+  
 International:
   - IATI
   - ogpl


### PR DESCRIPTION
Added @gsi-cyberjapan, Information Access Division of Geospatial Information Authority of Japan.
We are a division of the national geospatial information authority, or national mapping agency, of Japan.
See https://github.com/gsi-cyberjapan/gsimaps for an example of our activities.
