### PR TITLE
adding codeforibaraki

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -47,6 +47,7 @@ Civic Hackers:
   - unitedstates
   - votinginfoproject
   - yourmapper
+  - codeforibaraki
 
 Code For America:
   - betanyc


### PR DESCRIPTION
Code for Ibaraki is a civic hacking group in Japan.
