### PR TITLE
adding wakayama-pref-org

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -134,6 +134,7 @@ India:
 
 Japan:
   - gsi-cyberjapan
+  - wakayama-pref-org
 
 International:
   - IATI


### PR DESCRIPTION
@wakayama-pref-org is a government agency in Japan.
