### PR TITLE
Added the civic hacking group from Bulgaria

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -25,6 +25,7 @@ Civic Hackers:
   - mysociety
   - npp
   - nycedc
+  - obshtestvo
   - odhk
   - open-city
   - openaustralia


### PR DESCRIPTION
I've added [Obshtestvo](https://github.com/obshtestvo/) to the list. It's the civic hacking group in Bulgaria.

[Our website](http://www.obshtestvo.bg/) is only available in Bulgarian but I can answer any requests if needed.

We are the guys running the national open data portal: http://opendata.government.bg/ and several other projects and software requirements for public tenders in Bulgaria.
