### PR TITLE
Update governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -202,6 +202,9 @@ Norway:
   - KRD-KOMM-VL
   - metno
 
+Panama:
+  - IFARHU
+
 Paraguay:
   - mecpy
   - SENATICS


### PR DESCRIPTION
Adding Government Agency from Panama, IFARHU (Instituto para la Formación y Aprovechamiento de Recursos Humanos)
