### PR TITLE
Move Brighton and Hove to UK Councils

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -249,7 +249,6 @@ Switzerland:
 U.K. Central:
   - alphagov
   - BEACmodel
-  - brighton-hove-gov-uk
   - cabinetoffice
   - CarersBeta
   - companieshouse
@@ -295,6 +294,7 @@ U.K. Central:
 
 U.K. Councils:
   - BarnsleyCouncil
+  - brighton-hove-gov-uk
   - BristolCityCouncil
   - devoncc
   - DevonCountyCouncil


### PR DESCRIPTION
Brighton and Hove is a "UK Council" not a "UK Central Government" organisation.
