### PR TITLE
Move or remove non-government organizations

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -41,6 +41,7 @@ Civic Hackers:
   - openva
   - otvorenesudy
   - postcode
+  - rOpenGov
   - SpaceAdvocates
   - statedecoded
   - sunlightlabs

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -123,7 +123,6 @@ European Union:
   - europeana
 
 Finland:
-  - avoinministerio
   - City-of-Helsinki
   - HSLdevcom
   - Lounaispaikka
@@ -158,7 +157,6 @@ India:
 International:
   - IATI
   - ogpl
-  - rOpenGov
 
 Isle of Man:
   - Isle-Of-Man-Government
@@ -397,7 +395,6 @@ U.S. City:
   - nycdot
   - octolabs
   - OpenGovDC
-  - openlexington
   - p2g
   - pdxgis
   - PierceCountyWA


### PR DESCRIPTION
Moved two civic hacking groups to the civic hackers list, and removed one non-governmental, non-civic-hacker org, IMHO. Glad to add them back if I'm wrong.
