### PR TITLE
Just use site.title on the home page

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>{% if page.title %}{{ page.title }} | {% endif %}{{ site.title }}</title>
+  <title>{% if page.title and page.url != '/index.html' %}{{ page.title }} | {% endif %}{{ site.title }}</title>
   {% if page.description %}<meta name="description" content="{{ page.description }}">{% endif %}
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="/assets/img/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
Before, when viewing the home page

``` html
<title>GitHub and Government | GitHub and Government</title>
```

After:

``` html
<title>GitHub and Government</title>
```
