### PR TITLE
Link out to showcases, not individual projects

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ org_count: 60
     <div class="row-fluid section source-data-code">
       <div class="span4 animate-out">
         <h2>Open Source</h2>
-        <p><a href="https://github.com/alphagov/static/pull/94" target="_blank">
+        <p><a href="https://github.com/showcases/government" target="_blank">
           <img src="assets/img/open-source.png" alt="Pull request launching gov.uk"/></a>
         </p>
         <small>The UK Government launches its new site with a pull request.</small>
@@ -67,7 +67,7 @@ org_count: 60
 
       <div class="span4 animate-out">
         <h2>Open Data</h2>
-        <p><a href="https://github.com/benbalter/congressional-districts/commit/2233c76ca5bb059582d796f053775d8859198ec5?short_path=85d2c1b#diff-85d2c1b78193e963475250414e57940b" target="_blank">
+        <p><a href="https://github.com/showcases/open-data" target="_blank">
           <img src="assets/img/open-data.png" alt="GeoJSON diff of Illinois 4th Congressional District"/></a>
         </p>
         <small>The City of Chicago release geographic city data.</small>
@@ -75,7 +75,7 @@ org_count: 60
 
       <div class="span4 animate-out">
         <h2>Open Government</h2>
-        <p><a href="http://project-open-data.github.io/" target="_blank">
+        <p><a href="https://github.com/showcases/policies" target="_blank">
           <img src="assets/img/open-gov.png" alt="Project Open Data"/></a>
         </p>
         <small>The US Government Open Data policy on GitHub.</small>
@@ -83,7 +83,7 @@ org_count: 60
     </div>
 
   </div>
-  <p><a href="https://github.com/showcases/government">See more in the government showcase &rarr;</a></p>
+  <p><a href="https://github.com/showcases">See more showcases &rarr;</a></p>
 </div>
 
 


### PR DESCRIPTION
For the center three images on the main page, rather than link out to individual projects, we should link out to hand-curated showcases of open source, open data, and open government projects, so agencies looking for ideas of where to get started (or civic hackers looking to discover cool new projects) have a direct path to more examples than just three.
