### PR TITLE
added Namie town, Fukushima, Japan

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -184,6 +184,7 @@ Japan:
   - nhohq
   - nims-library
   - wakayama-pref-org
+  - codefornamie
 
 Latvia:
   - CSBLatvia


### PR DESCRIPTION
I've added Namie town official repository.
Namie town is located in Fukushima Pref. Japan.
