### PR TITLE
New Zealand Office of the Privacy Commissioner shares under open source license

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -207,6 +207,7 @@ New Zealand:
   - localgovernment
   - nz-mbie
   - NZWellingtonCityCouncil
+  - opcnz
   - R9BetterAPIs
   - te-papa
 


### PR DESCRIPTION
The OPCNZ is sharing code under open source licenses in an effort to help other organisations in the NZ public sector (and even in the wider FOSS community) improve the privacy of their communications in digital channels. To aid in discoverability it would be great to include them in this list of govt GitHub users.
