### PR TITLE
use avatars0-3 based on org name length

### DIFF
--- a/_includes/org-table.html
+++ b/_includes/org-table.html
@@ -16,7 +16,9 @@
         <tr>
           <td>
             <a href="https://github.com/{{ org }}" title="{{ org }}">
-            <img src="https://avatars.githubusercontent.com/{{ org }}?v=3&amp;s=40" width="40" height="40" alt="{{ org }}"></a>
+
+
+            <img src="https://avatars{{ org | size | modulo: 4 }}.githubusercontent.com/{{ org }}?v=3&amp;s=40" width="40" height="40" alt="{{ org }}"></a>
           </td>
           <td>
             <p><a href="https://github.com/{{ org }}" title="{{ org }}">{{ org }}</a></p>

--- a/_includes/org-table.html
+++ b/_includes/org-table.html
@@ -16,8 +16,6 @@
         <tr>
           <td>
             <a href="https://github.com/{{ org }}" title="{{ org }}">
-
-
             <img src="https://avatars{{ org | size | modulo: 4 }}.githubusercontent.com/{{ org }}?v=3&amp;s=40" width="40" height="40" alt="{{ org }}"></a>
           </td>
           <td>

--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@ org_count: 60
 
 <div class="full-screen featured-orgs">
   {% for org in site.featured_orgs %}
-  <a href="http://www.github.com/{{ org }}"><img class="animate-in" src="https://avatars.githubusercontent.com/{{ org }}?v=3&amp;s=74" width="80" alt="View {{ org }}'s profile on GitHub"></a>
+  <a href="http://www.github.com/{{ org }}"><img class="animate-in" src="https://avatars{{ org | size | modulo: 4 }}.githubusercontent.com/{{ org }}?v=3&amp;s=74" width="80" alt="View {{ org }}'s profile on GitHub"></a>
   {% endfor %}
 </div>
 </div>


### PR DESCRIPTION
A follow up to https://github.com/github/government.github.com/pull/404#discussion_r40442384, this uses the `avatars0` through `avatars3` subdomains for loading avatars by calculating mod 4 of the length of the org name. A bit of a hack, but it works to consistently generate 0-3 in a somewhat random distribution.

/cc @technoweenie and @sonalkr132!
