### PR TITLE
Added navikt organization under Norway

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -226,6 +226,7 @@ Norway:
   - kartverket
   - KRD-KOMM-VL
   - metno
+  - navikt
 
 Panama:
   - IFARHU


### PR DESCRIPTION
GitHub-govt. organization 'navikt' is the IT-department for the Norwegian labour and welfare administration
