### PR TITLE
Better CFA fetching

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -1,21 +1,31 @@
 # Add non-profits or groups focused on government
 
 Civic Hackers:
+  - akroncivichackathon
   - bundestag
+  - CfABrigadePhiladelphia
   - civio
   - CODE-TJ
+  - Code4HR
   - CodeandoMexico
   - CodeforABQ
   - codeforafrica
+  - CodeforBirmingham
+  - CodeForCharlotte
+  - codefordurham
   - codeforeurope
+  - CodeForFtL
+  - codeforhuntsville
   - codeforibaraki
   - codeforjapan
+  - codeforseattle
   - Codeforseoul
   - codefortomorrow
   - databr
   - datauy
   - dataviz
   - dobtco
+  - dssg
   - dxw
   - g0v
   - gitmachines
@@ -34,8 +44,10 @@ Civic Hackers:
   - open-city
   - openaustralia
   - OpenDataTajikistan
+  - opengovernment
   - opengovfoundation
   - OpenGovLD
+  - openjc
   - OpenKratio
   - opennewzealand
   - opennorth
@@ -47,6 +59,7 @@ Civic Hackers:
   - otvorenesudy
   - postcode
   - rOpenGov
+  - smartchicago
   - SpaceAdvocates
   - statedecoded
   - sunlightlabs

--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -5,8 +5,8 @@ Civic Hackers:
   - civio
   - CODE-TJ
   - CodeandoMexico
-  - codeforafrica
   - CodeforABQ
+  - codeforafrica
   - codeforeurope
   - codeforibaraki
   - codeforjapan
@@ -56,6 +56,27 @@ Civic Hackers:
   - unitedstates
   - votinginfoproject
   - yourmapper
+
+Code for All:
+  - code4sa
+  - codeandomexico
+  - codeforafrica
+  - codeforamerica
+  - codeforaustralia
+  - codeforbrazil
+  - codeforcanada
+  - codeforeurope
+  - codeforgermany
+  - codeforireland
+  - codeforjapan
+  - codeforpakistan
+  - codeforseoul
+  - codeforthecaribbean
+  - codefortomorrow
+  - g0v
+  - hackingmty
+  - kodujdlapolski
+  - labplc
 
 Code For America:
   - a2civictech
@@ -153,24 +174,3 @@ Open Knowledge Foundation:
   - okfn
   - okfn-brasil
   - okfngr
-
-Code for All:
-  - code4sa
-  - codeandomexico
-  - codeforafrica
-  - codeforamerica
-  - codeforaustralia
-  - codeforbrazil
-  - codeforcanada
-  - codeforeurope
-  - codeforgermany
-  - codeforireland
-  - codeforjapan
-  - codeforpakistan
-  - codeforseoul
-  - codeforthecaribbean
-  - codefortomorrow
-  - g0v
-  - hackingmty
-  - kodujdlapolski
-  - labplc

--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -58,75 +58,94 @@ Civic Hackers:
   - yourmapper
 
 Code For America:
-  - akroncivichackathon
+  - a2civictech
+  - arduina
+  - ballpointpenguin
   - betanyc
-  - CfABrigadePhiladelphia
-  - chip-rosenthal
+  - chriswhong
   - civicdata
+  - clhenrick
   - code-for-miami
-  - Code4HR
+  - code-for-nashville
+  - code-for-tb
+  - code4hr
   - code4maine
   - code4puertorico
-  - codeforafrica
-  - codeforamerica
+  - code4sac
+  - codeforabq
+  - codeforanchorage
   - codeforasheville
   - codeforatlanta
-  - codeforaustralia
-  - CodeforBirmingham
   - codeforbirmingham
   - codeforboston
+  - codeforboulder
   - codeforbtv
-  - codeforcanada
-  - CodeForCharlotte
+  - codeforcary
   - codeforcharlotte
   - codeforchemnitz
   - codeforcroatia
   - codefordayton
   - codefordc
   - codefordenver
-  - codefordurham
-  - CodeForFtL
+  - codeforftl
+  - codeforgiessen
   - codeforgso
   - codeforhawaii
-  - codeforhuntsville
-  - codeforireland
+  - codeforibaraki
+  - codeforjerseycity
+  - codeforkanazawa-org
+  - codeforkansascity
+  - codeforkobe
   - codeforleipzig
+  - codeformuenster
+  - codeformunich
+  - codefornewark
   - codefornrv
-  - codeforpakistan
+  - codeforokinawa
   - codeforportland
+  - codeforrockford
   - codeforrva
-  - codeforseattle
-  - codeforseoul
-  - codeforthecaribbean
+  - codeforsanjose
+  - codeforsapporo
+  - codeforsummitcounty
   - codefortucson
   - codefortulsa
   - codeforvegas
   - codeisland
-  - dssg
+  - datamade
+  - dirkschumacher
   - friendlycode
   - hackforla
   - hackingmadison
-  - hackingmty
-  - kodujdlapolski
+  - hackmichiana
   - koelnapi
-  - mysociety
+  - localwiki
   - nuknightlab
   - open-austin
-  - open-city
   - openchattanooga
-  - opengovernment
-  - openjc
+  - opencleveland
+  - opendata-heilbronn
+  - opendatapolicingnc
+  - opendatastl
+  - openkawasaki
   - openlexington
   - opennebraska
   - openoakland
   - openpgh
   - opensaltlake
+  - opensandiego
   - opensatx
+  - openseattle
   - opensyracuse
+  - opentwincities
+  - openwichita
   - openzagreb
   - sarl-hackerspace
-  - smartchicago
-  - talos
+  - sfbrigade
+  - smartercleanup
+  - substars
+  - tursics
+  - wevoteeducation
 
 Open Knowledge Foundation:
   - okfde
@@ -134,3 +153,24 @@ Open Knowledge Foundation:
   - okfn
   - okfn-brasil
   - okfngr
+
+Code for All:
+  - code4sa
+  - codeandomexico
+  - codeforafrica
+  - codeforamerica
+  - codeforaustralia
+  - codeforbrazil
+  - codeforcanada
+  - codeforeurope
+  - codeforgermany
+  - codeforireland
+  - codeforjapan
+  - codeforpakistan
+  - codeforseoul
+  - codeforthecaribbean
+  - codefortomorrow
+  - g0v
+  - hackingmty
+  - kodujdlapolski
+  - labplc

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -185,11 +185,11 @@ Italy:
 
 Japan:
   - city-of-kobe
+  - codefornamie
   - gsi-cyberjapan
   - nhohq
   - nims-library
   - wakayama-pref-org
-  - codefornamie
 
 Latvia:
   - CSBLatvia

--- a/script/cibuild
+++ b/script/cibuild
@@ -9,4 +9,4 @@ export PATH=/usr/share/rbenv/shims:$PATH RBENV_VERSION=$(cat .ruby-version)
 bundle exec rake test
 
 # Ensure the Code for America and Code for All list only contain official chapters/partners
-bundle exec script/fetch-fa
+bundle exec script/fetch-cfa

--- a/script/cibuild
+++ b/script/cibuild
@@ -7,3 +7,6 @@ script/branding
 export PATH=/usr/share/rbenv/shims:$PATH RBENV_VERSION=$(cat .ruby-version)
 
 bundle exec rake test
+
+# Ensure the Code for America and Code for All list only contain official chapters/partners
+bundle exec script/fetch-fa

--- a/script/fetch-cfa
+++ b/script/fetch-cfa
@@ -56,7 +56,8 @@ class CFAFetcher
     logger.info "Found #{brigades.count} Brigades"
 
     to_be_removed = org_file["Code For America"] - brigades - code_for_all_orgs
-    logger.info "Removing the following orgs: \n#{to_be_removed.join("\n")}" unless to_be_removed.empty?
+    msg = "The following orgs aren't listed on http://codeforamerica.org/api/#api-organizations: \n"
+    logger.info msg + to_be_removed.join("\n") unless to_be_removed.empty?
 
     org_file["Code For America"] = brigades
     org_file["Code for All"] = code_for_all_orgs

--- a/script/fetch-cfa
+++ b/script/fetch-cfa
@@ -5,30 +5,72 @@
 require "open-uri"
 require "json"
 require "yaml"
+require 'addressable/uri'
+require "addressable/template"
+require 'logger'
 
-org_file = YAML.load_file "./_data/civic_hackers.yml"
-data = JSON.parse open("http://codeforamerica.org/api/organizations").read
-gov_orgs = YAML.load_file("./_data/governments.yml").values.flatten.map { |o| o.downcase }
+class CFAFetcher
 
-orgs = []
-data["objects"].each do |org|
-  org["current_projects"].each do |project|
-    orgs.push project["github_details"]["owner"]["login"]
+  def logger
+    @logger ||= Logger.new(STDOUT)
+  end
+
+  def endpoint_uri(type=nil)
+    "http://codeforamerica.org/api/organizations?per_page=200&type=#{type}"
+  end
+
+  def get_orgs(type=nil)
+    logger.info "Fetching #{type.gsub("+", " ")} orgs"
+    uri = endpoint_uri(type)
+    data = JSON.parse open(uri).read
+    data["objects"].map do |org|
+      org["current_projects"].map do |project|
+        project["github_details"]["owner"]["login"] unless project["github_details"].nil?
+      end
+    end.flatten.compact.uniq.map { |o| o.downcase }.sort
+  end
+
+  def org_file_path
+    File.expand_path "../_data/civic_hackers.yml", File.dirname(__FILE__)
+  end
+
+  def org_file
+    @org_file ||= YAML.load_file org_file_path
+  end
+
+  def gov_orgs
+    @gov_orgs ||= YAML.load_file("./_data/governments.yml").values.flatten.map { |o| o.downcase }
+  end
+
+  def code_for_all_orgs
+    @code_for_all_orgs ||= get_orgs("Code+for+All") - gov_orgs
+  end
+
+  def brigades
+    @brigades ||= get_orgs("Brigade") - code_for_all_orgs - gov_orgs
+  end
+
+  def fetch
+    logger.info "Updating CFA list..."
+    logger.info "Found #{code_for_all_orgs.count} Code for All orgs"
+    logger.info "Found #{brigades.count} Brigades"
+
+    to_be_removed = org_file["Code For America"] - brigades - code_for_all_orgs
+    logger.info "Removing the following orgs: \n#{to_be_removed.join("\n")}" unless to_be_removed.empty?
+
+    org_file["Code For America"] = brigades
+    org_file["Code for All"] = code_for_all_orgs
+
+    comment = File.open(org_file_path).read.lines.first
+    output = comment
+    output << "\n"
+    output << org_file.to_yaml.sub(/\A---\n/, "").gsub(/^-/, "  -").gsub(/\n([^ ])/, "\n\n\\1")
+
+    File.write(org_file_path, output)
+
+    logger.info "Done."
+    exit to_be_removed.empty? ? 0 : 1
   end
 end
 
-orgs.uniq!
-orgs.reject! { |org| gov_orgs.include?(org.downcase) }
-
-orgs.each do |org|
-  org_file["Code For America"].push(org.downcase) unless org_file["Code For America"].include?(org.downcase)
-end
-
-output = {
-  "Code For America" => org_file["Code For America"].uniq.sort do
-      |a,b| a.upcase <=> b.upcase
-  end
-}
-
-puts "To be pasted into _data/civic_hackers.yml"
-puts output.to_yaml
+CFAFetcher.new.fetch


### PR DESCRIPTION
This:
1. Breaks Code for America and Code for All into dedicated sections
2. Ensures the civic hacker list only contains Code for America and Code for All orgs that are returned from the API

The following orgs will be removed:
- @akroncivichackathon
- @CfABrigadePhiladelphia
- @chip-rosenthal
- @Code4HR
- @CodeforBirmingham
- @CodeForCharlotte
- @codefordurham
- @CodeForFtL
- @codeforhuntsville
- @codeforseattle
- @dssg
- @mysociety
- @open-city
- @opengovernment
- @openjc
- @smartchicago
- @talos
