### PR TITLE
Added skat-repositories to list

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -122,6 +122,9 @@ Colombia:
   - evaluon
   - idu-bogota
 
+Denmark:
+  - skat-repositories
+
 Ecuador:
   - inamhi
   - innovacionsnap


### PR DESCRIPTION
Please append SKAT (Danish Tax and Customs Administration, http://www.skat.dk) to the list of government organizations.
