### PR TITLE
Downgrade HTML proofer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,9 +3,10 @@ source "https://rubygems.org"
 gem "github-pages"
 gem "jekyll-seo-tag"
 gem "rake"
+gem 'nokogiri'
 
 group :development, :test do
-  gem "html-proofer"
+  gem "html-proofer", '2.5.2'
   gem 'typhoeus'
   gem 'octokit'
   gem 'parallel'

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,6 @@ source "https://rubygems.org"
 gem "github-pages"
 gem "jekyll-seo-tag"
 gem "rake"
-gem 'nokogiri'
 
 group :development, :test do
   gem "html-proofer", '2.5.2'

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -631,7 +631,6 @@ U.S. States:
   - gocodecolorado
   - IDAHO-DOC-NCOMS
   - idahofishgame
-  - InDEM
   - investmentboard
   - LADCO
   - LibraryofVA
@@ -661,7 +660,6 @@ U.S. States:
   - Virginia-House-of-Delegates
   - vtrans
   - vtrans-rail
-  - WA-OCIO
   - wadoh
   - WisconsinDPI
   - wsdot


### PR DESCRIPTION
See the output of https://travis-ci.org/github/government.github.com/builds/95851068.

It seems HTML Proofer `2.6.0` breaks the build. I suspect it's related to the escaping in https://github.com/gjtorikian/html-proofer/pull/273.

/cc @gjtorikian 
