### PR TITLE
add the City of Nanterre

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -157,6 +157,7 @@ France:
   - communaute-cimi
   - DGFiP
   - disic
+  - nanterre
   - erasme
   - etalab
   - polewebmaedi


### PR DESCRIPTION
adding the City of Nanterre's github organization page to the french local government list.
