### PR TITLE
Redirect /best-practices/ to government.github.io/best-practices

### DIFF
--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,0 +1,3 @@
+---
+redirect_to: http://government.github.com/best-practices/
+---

--- a/docs/best-practices.md
+++ b/docs/best-practices.md
@@ -1,3 +1,4 @@
 ---
 redirect_to: http://government.github.com/best-practices/
+permalink: /best-practices/
 ---


### PR DESCRIPTION
Which now publishes out a 0.1 of the best practices documentation as developed by the peer group:

http://government.github.io/best-practices/
