### PR TITLE
Rename of 'skat-repositories' to 'skat'

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -123,7 +123,7 @@ Colombia:
   - idu-bogota
 
 Denmark:
-  - skat-repositories
+  - skat
 
 Ecuador:
   - inamhi


### PR DESCRIPTION
With reference to rename of repo done by GitHub support
