### PR TITLE
Adds DCgov to governments.yml, removes octolabs

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -425,6 +425,7 @@ U.S. City:
   - datala
   - dataseattlegov
   - DCCouncil
+  - DCgov
   - DenverDev
   - digitalinclusion
   - dotnyc
@@ -438,7 +439,6 @@ U.S. City:
   - monum
   - NYCComptroller
   - nycdot
-  - octolabs
   - OpenGovDC
   - p2g
   - pdxgis


### PR DESCRIPTION
DCgov is the new GitHub organization for the government of the District of Columbia. octolabs is defunct and hasn't been utilized since 2010.
