### PR TITLE
Add the International Hacker Community (IHC)

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -50,6 +50,7 @@ Civic Hackers:
   - unitedstates
   - votinginfoproject
   - yourmapper
+  - ihcom
 
 Code for All:
   - code4sa


### PR DESCRIPTION
@benbalter @defunkt @pjhyett @technoweenie @Caged @atmos  @jlord

---

Hi, :smile:

I added the **International Hacker Community (IHC)**.
#### About

The International Hacker Community (short: IHC) is a non-profit community organisation (Civic Hackers) which is focused on government security.

Yours,
Suriyaa Kudo :octocat:
