### PR TITLE
Move inline JS before the end body tag.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -19,8 +19,74 @@
       </div>
     </footer>
 
+  <script src="/assets/vendor/jquery/jquery.min.js"></script>
   <script src="/assets/vendor/anchor-js/anchor.min.js"></script>
   <script>anchors.add('.org-table h4');</script>
+
+{% if page.layout == "home" %}
+<script>
+  $(function() {
+
+    $animateIn = $(".animate-in");
+    $animateOut = $(".animate-out");
+    var animateInOffset = 100;
+    var animateOutOffset = 200;
+
+
+    $animateIn.addClass("pre-animate");
+    $animateOut.addClass("pre-animate-out");
+
+    $(window).scroll(function(e) {
+      var windowHeight = $(window).height(),
+        windowScrollPosition = $(window).scrollTop(),
+        bottomScrollPosition = windowHeight + windowScrollPosition;
+
+      $animateIn.each(function(i, element) {
+        if ($(element).offset().top + animateInOffset < bottomScrollPosition) {
+          $(element).removeClass('pre-animate');
+        };
+      });
+
+      $animateOut.each(function(i, element) {
+        if ($(element).offset().top + animateOutOffset < bottomScrollPosition) {
+          $(element).removeClass('pre-animate-out');
+        };
+      });
+    });
+  });
+</script>
+{% endif %}
+
+{% if page.layout == "support-page" %}
+<script>
+  $(document).ready(function () {
+    (function ($) {
+      $('#filter').keyup(function () {
+        var rex = new RegExp($(this).val(), 'i');
+        $('.searchable tr').hide();
+        $('.searchable tr').filter(function () {
+            return rex.test($(this).text());
+        }).show();
+
+        if ($('.govtable tr:visible').length === 0) {
+          $('.govtable.no-matches').show();
+        } else {
+          $('.govtable.no-matches').hide();
+          $('.govtable.table-header').show();
+        };
+
+        if ($('.civictable tr:visible').length === 0) {
+          $('.civictable.no-matches').show();
+        } else {
+          $('.civictable.no-matches').hide();
+          $('.civictable.table-header').show();
+        };
+      })
+    }(jQuery));
+  });
+</script>
+{% endif %}
+
   </body>
 </html>
 <!-- Proudly powered by GitHub Pages ~ Generated {{ site.time }} -->

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,8 +6,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="shortcut icon" href="/assets/img/favicon.ico" type="image/x-icon">
   <link rel="stylesheet" href="/assets/css/style.css">
-  <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700' rel='stylesheet' type='text/css'>
-  <script src="/assets/vendor/jquery/jquery.min.js"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,300,700">
   {% include analytics.html %}
   {% seo %}
 </head>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -16,36 +16,4 @@
 
 </div>
 
-<script>
-  $(function() {
-
-    $animateIn = $(".animate-in");
-    $animateOut = $(".animate-out");
-    var animateInOffset = 100;
-    var animateOutOffset = 200;
-
-
-    $animateIn.addClass("pre-animate");
-    $animateOut.addClass("pre-animate-out");
-
-    $(window).scroll(function(e) {
-      var windowHeight = $(window).height(),
-        windowScrollPosition = $(window).scrollTop(),
-        bottomScrollPosition = windowHeight + windowScrollPosition;
-
-      $animateIn.each(function(i, element) {
-        if ($(element).offset().top + animateInOffset < bottomScrollPosition) {
-          $(element).removeClass('pre-animate');
-        };
-      });
-
-      $animateOut.each(function(i, element) {
-        if ($(element).offset().top + animateOutOffset < bottomScrollPosition) {
-          $(element).removeClass('pre-animate-out');
-        };
-      });
-    });
-  });
-</script>
-
 {% include footer.html %}

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -12,32 +12,4 @@
         {{ content }}
   </div>
 
-<script>
-  $(document).ready(function () {
-    (function ($) {
-      $('#filter').keyup(function () {
-        var rex = new RegExp($(this).val(), 'i');
-        $('.searchable tr').hide();
-        $('.searchable tr').filter(function () {
-            return rex.test($(this).text());
-        }).show();
-
-        if ($('.govtable tr:visible').length === 0) {
-          $('.govtable.no-matches').show();
-        } else {
-          $('.govtable.no-matches').hide();
-          $('.govtable.table-header').show();
-        };
-
-        if ($('.civictable tr:visible').length === 0) {
-          $('.civictable.no-matches').show();
-        } else {
-          $('.civictable.no-matches').hide();
-          $('.civictable.table-header').show();
-        };
-      })
-    }(jQuery));
-  });
-</script>
-
 {% include footer.html %}


### PR DESCRIPTION
/CC @benbalter 

Unfortunately I cannot test this locally because I keep getting the following:

```
C:\Users\xmr\Desktop\government.github.com>ruby -v && gem -v
ruby 2.2.4p230 (2015-12-16 revision 53155) [x64-mingw32]
2.5.2

C:\Users\xmr\Desktop\government.github.com>bundle exec jekyll s
Configuration file: C:/Users/xmr/Desktop/government.github.com/_config.yml
            Source: C:/Users/xmr/Desktop/government.github.com
       Destination: C:/Users/xmr/Desktop/government.github.com/_site
 Incremental build: disabled. Enable with --incremental
      Generating...
  Conversion error: Jekyll::Converters::Scss encountered an error while converting 'assets/css/style.scss':
                    File to import not found or unreadable: bootstrap/stylesheet
s/bootstrap. Load path: C:/Users/xmr/Desktop/government.github.com/_sass on line 2
jekyll 3.0.3 | Error:  File to import not found or unreadable: bootstrap/stylesheets/bootstrap.
Load path: C:/Users/xmr/Desktop/government.github.com/_sass on line 2
```
