### PR TITLE
Request to add vegvesen to governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -252,6 +252,7 @@ Norway:
   - KRD-KOMM-VL
   - metno
   - navikt
+  - vegvesen
 
 Panama:
   - IFARHU


### PR DESCRIPTION
Vegvesen.no is the official website for the Norwegian Public Roads Administration
