### PR TITLE
Update governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -252,6 +252,8 @@ Norway:
   - KRD-KOMM-VL
   - metno
   - navikt
+  - rutebanken
+  - ruterno
   - vegvesen
 
 Panama:


### PR DESCRIPTION
Add Ruter AS (Public transport authority of Oslo) and Rutebanken AS (National authority for coordination of public transport information in Norway, owned by vegvesen)
