### PR TITLE
Add mxabierto to list

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -234,6 +234,7 @@ Mexico:
   - inmegen
   - profeco
   - redoaxacadetodos
+  - mxabierto
 
 New Zealand:
   - CanterburyRegionalCouncil


### PR DESCRIPTION
mxabierto is the repository for the Mexican open data policy
