### PR TITLE
Fixed broken link to Singapore Gov Tech

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -287,7 +287,7 @@ Saudi Arabia:
   - SAS-NCDC
 
 Singapore:
-  - idagds
+  - govtechsg
   - moexmen
 
 South Africa:


### PR DESCRIPTION
The username for this org has changed so the CI link check was breaking. Fixed it now.
