### PR TITLE
Removed Data Seattle.

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -449,7 +449,6 @@ U.S. City:
   - CORaleigh
   - CUMTD
   - datala
-  - dataseattlegov
   - DCCouncil
   - DCgov
   - DenverDev


### PR DESCRIPTION
Seattle Data Gov org has disappeared, so the CI link checker was breaking. Removed the link.
