### PR TITLE
Update governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -577,6 +577,7 @@ U.S. Federal:
   - ombegov
   - Open-Sat
   - opengovplatform
+  - openopps
   - ozoneplatform
   - peacecorps
   - petsc


### PR DESCRIPTION
Added https://github.com/openopps organization. 

> OpenOpps is the open source platform that supports the Open Opportunities program. As open source software, it can be deployed by state or local governments or in the private sector. It is free to use by anyone who can has technical operations staff and passion to start a new program, and we welcome everyone who would like to contribute to improving the platform.
