### PR TITLE
Included civic-tech organization Open Data Kosovo

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -25,6 +25,7 @@ Civic Hackers:
   - odhk
   - open-city
   - openaustralia
+  - opendatakosovo
   - opendatatajikistan
   - opengovfoundation
   - opengovld


### PR DESCRIPTION
Open Data Kosovo is a civic-tech organization involved in digital product development through youth engagement around open data: http://opendatakosovo.org/