### PR TITLE
Added Girls Coding Kosova under Civic Hackers

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -26,6 +26,7 @@ Civic Hackers:
   - open-city
   - openaustralia
   - opendatakosovo
+  - girlscodingkosova
   - opendatatajikistan
   - opengovfoundation
   - opengovld


### PR DESCRIPTION
Added Girls Coding Kosova under Civic Hackers 
Girls Coding Kosova's mission is to encourage women to reach their full academic and professional potential in technical fields. Its network spans across all municipalities in Kosovo and includes over six hundred (600) active young members aged between fifteen (15) and twenty-five (25). GCK is constantly working on bringing events to the young and enthusiasts girls of Kosovo to encourage them to code, launch companies or work as developers in other exciting startups in the country. 

Our vision is to create a free-of-gender-bias IT sector in Kosovo and the Balkan Region by:

- Increasing the number of interested women in technology/programming
- Expanding number of women to consider programming as an academic profession
- Increasing the number of entrepreneurial women in innovative fields using coding and programming.
- Encouraging young girls’ early exposure to coding and software programming

Our mission is important because technology is becoming an essential part of our daily lives. There are many fields related to technology; internet, smartphones, social media. Considering the importance of technology and the current situation in Kosovo, where there is an obvious lack of women interested in the technology industry, especially in programming, we consider this initiative to be important in changing the current situation.