### PR TITLE
removing fccdev org, no longer vali

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -548,7 +548,6 @@ U.S. Federal:
   - erdc-cm
   - eregs
   - fcc
-  - FCCdev
   - fda
   - Federal-Aviation-Administration
   - federaltradecommission


### PR DESCRIPTION
FCCDev org was removed, so deleting it from list.

cc/ @bcaswell