### PR TITLE
Update the Fetch-US script to new API endpoint and pull down latest

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -221,7 +221,7 @@ Japan:
   - nhohq
   - nims-library
   - wakayama-pref-org
-  
+
 Jersey:
   - statesofjersey
 
@@ -542,8 +542,10 @@ U.S. Federal:
   - defense-cyber-crime-center
   - demand-driven-open-data
   - department-of-veterans-affairs
+  - deptofdefense
   - dhs-ncats
   - didsr
+  - digital-analytics-program
   - EEOC
   - energyapps
   - erdc-cm
@@ -612,6 +614,7 @@ U.S. Federal:
   - SERVIR
   - state-hiu
   - sunpy
+  - us-bea
   - US-CBP
   - usagov
   - usaid

--- a/script/fetch-us
+++ b/script/fetch-us
@@ -21,8 +21,8 @@ us_gov   = org_file['U.S. Federal'].map(&:downcase)
 research = YAML.load_file('./_data/research.yml').values.flatten
 existing = (gov + research).flatten.map(&:downcase)
 
-orgs = JSON.parse open('http://registry.usa.gov/accounts?service_id=GitHub&format=json').read
-orgs = orgs['accounts'].collect { |data| data['account'] }
+orgs = JSON.parse open('https://usdigitalregistry.digitalgov.gov/api/v1/social_media.json?services=github').read
+orgs = orgs['results'].collect { |data| data['account'] }
 
 orgs.each do |org|
   next if existing.include?(org.downcase)


### PR DESCRIPTION
The digital registrery currenty has the following user accounts:
- usopm
- fccdata

It is also missing the following that are registered here, but not in the registry:
- 18f
- adl-aicc
- adlnet
- afrl
- arcticlcc
- bbginnovate
- bfelob
- blue-button
- businessusa
- ca-cst-library
- ca-cst-sii
- ccmc
- cfpb
- cmsgov
- commercedataservice
- commercegov
- defense-cyber-crime-center
- demand-driven-open-data
- department-of-veterans-affairs
- dhs-ncats
- didsr
- eeoc
- erdc-cm
- eregs
- fcc
- fda
- federal-aviation-administration
- federaltradecommission
- fedspendingtransparency
- globegit
- gopleader
- greatsmokymountainsnationalpark
- gsa
- gsa-archive
- hhs
- historyatstate
- iip-design
- imdprojects
- informaticslab
- irsgov
- keplergo
- libraryofcongress
- m-o-s-e-s
- mcc-gov
- nasa-develop
- nasa-gibs
- nasa-rdt
- nasa-tournament-lab
- nasaworldwind
- nationalparkservice
- ncrn
- neogeographytoolkit
- nesii
- ngds
- nhanes
- nidcd
- nmml
- noaa-gfdl
- ntia
- ombegov
- open-sat
- opengovplatform
- ozoneplatform
- peacecorps
- presidential-innovation-fellows
- project-open-data
- radiofreeasia
- redhawksdr
- sbstusa
- selectusa
- servir
- state-hiu
- sunpy
- us-cbp
- usagov
- usaid
- usajobs
- usasearch
- usbr
- uscensusbureau
- uscis
- usda
- usda-ars-agil
- usda-ers
- usda-fsa
- usda-vs
- usdepartmentoflabor
- usdeptveteransaffairs
- usds
- usfws
- usg-scope
- usgcrp
- usgpo
- usgs
- usgs-astrogeology
- usgs-cida
- usgs-cmg
- usgs-eros
- usgs-owi
- usgs-r
- usgs-wim
- usindianaffairs
- usinterior
- usnationalarchives
- usps
- uspto
- usstatedept
- vhainnovations
- virtual-world-framework
- visionworkbench
- wfmrda
- whitehouse