### PR TITLE
Adding Uruguay's digital political party

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -95,6 +95,7 @@ Civic Hackers:
   - opented
   - openva
   - otvorenesudy
+  - PartidoDigital
   - planningalerts-scrapers
   - plonegov
   - poplus


### PR DESCRIPTION
Partido Digital is the first Uruguayan Open Source digital-based political party where transparency and participation are crucial.