### PR TITLE
Update the fetch-cfa script and resync

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -2,10 +2,12 @@
 
 Civic Hackers:
   - 16iacc
+  - activate
   - adhocteam
   - akroncivichackathon
   - avoindata
-  - BD-IATI
+  - bd-iati
+  - betanyc
   - ciudadanointeligente
   - civcoms
   - civic-commons
@@ -17,23 +19,25 @@ Civic Hackers:
   - codeandomonterrey
   - codeforhuntsville
   - codeforoakland
+  - codeforphilly
   - codeforseattle
   - codesy
   - correctiv
   - databr
-  - DataKind
-  - DataKind-UK
+  - datakind
+  - datakind-uk
   - datamade
   - datauy
   - dataviz
   - dclegalhackers
-  - DemocracyClub
+  - democracyclub
   - democracyworks
   - developmentseed
   - dobtco
   - drupal4gov
   - dssg
   - dxw
+  - e-government-ua
   - electionleaflets
   - everypolitician
   - everypolitician-scrapers
@@ -51,13 +55,16 @@ Civic Hackers:
   - koelnapi
   - lisbon-opendata
   - localdata
+  - localwiki
+  - mainecivichackday
   - mapnificent
-  - mapseed
   - myanmarapi
   - mysociety
+  - nationaldayofcivichacking
   - netzwerkrecherche
   - npp
-  - NRGI
+  - nrgi
+  - nucivic
   - nycedc
   - obshtestvo
   - occrp
@@ -95,7 +102,7 @@ Civic Hackers:
   - opented
   - openva
   - otvorenesudy
-  - PartidoDigital
+  - partidodigital
   - planningalerts-scrapers
   - plonegov
   - poplus
@@ -142,9 +149,8 @@ Code for All:
 
 Code For America:
   - a2civictech
-  - activate
-  - betanyc
-  - bikesafety
+  - analyticsmj
+  - blue-sky-skunkworks
   - caciviclab
   - cforlando
   - civicdata
@@ -180,6 +186,7 @@ Code For America:
   - codeforftl
   - codeforgiessen
   - codeforgso
+  - codeforhamburg
   - codeforhawaii
   - codeforibaraki
   - codeforjerseycity
@@ -190,10 +197,10 @@ Code For America:
   - codeformuenster
   - codeformunich
   - codefornh
+  - codefornola
   - codefornrv
   - codeforokinawa
   - codeforpg
-  - codeforphilly
   - codeforportland
   - codeforraleigh
   - codeforrockford
@@ -201,20 +208,19 @@ Code For America:
   - codeforsanjose
   - codeforsapporo
   - codeforsummitcounty
+  - codefortallahassee
   - codefortucson
   - codefortulsa
   - codefortuscaloosa
   - codeforvegas
   - codeisland
-  - e-government-ua
   - friendlycode
   - hackforla
   - hackingmadison
   - hackmichiana
-  - localwiki
-  - mainecivichackday
-  - nationaldayofcivichacking
-  - nucivic
+  - hacktahoe
+  - justopensource
+  - mapseed
   - nuknightlab
   - open-austin
   - openchattanooga
@@ -235,6 +241,8 @@ Code For America:
   - sarl-hackerspace
   - sfbrigade
   - smartchicago
+  - webuildcity
+  - wevote
 
 Open Knowledge Foundation:
   - bundestag

--- a/script/fetch-cfa
+++ b/script/fetch-cfa
@@ -13,7 +13,7 @@ require 'typhoeus'
 
 module CFA
   class Fetcher
-    ENDPOINT = 'http://codeforamerica.org/api/organizations'
+    ENDPOINT = 'http://api.codeforamerica.org/api/organizations'
     DEFAULT_ARGS = {
       'per_page' => 200
     }.freeze


### PR DESCRIPTION
Looks like the endpoint was moved, so I updated the url.
After running the script there were a handeful of orgs that we're in there api, so they were moved under Civic Hackers.
The only real deletion with this was the `bikesaftey` org, which appears to be removed.