### PR TITLE
Add new Govcloud redirect/landing page

### DIFF
--- a/docs/gov-cloud.md
+++ b/docs/gov-cloud.md
@@ -1,0 +1,1 @@
+This page will redirect to enterprise.github.com/aws/gov-cloud.md

--- a/docs/gov-cloud.md
+++ b/docs/gov-cloud.md
@@ -1,1 +1,5 @@
-This page will redirect to enterprise.github.com/aws/gov-cloud.md
+---
+title: GitHub Enterprise on AWS GovCloud
+redirect_to:
+  - https://enterprise.github.com/aws/gov-cloud
+---


### PR DESCRIPTION
Just redirect to the existing enterprise.github.com/aws/gov-cloud page for now