### PR TITLE
Fixing gov_cloud redirect

### DIFF
--- a/docs/gov-cloud.md
+++ b/docs/gov-cloud.md
@@ -1,5 +1,4 @@
 ---
 title: GitHub Enterprise on AWS GovCloud
-redirect_to:
-  - https://enterprise.github.com/aws/gov-cloud
+redirect_to: https://enterprise.github.com/aws/gov-cloud
 ---

--- a/docs/gov-cloud.md
+++ b/docs/gov-cloud.md
@@ -1,4 +1,4 @@
 ---
 title: GitHub Enterprise on AWS GovCloud
-redirect_to: https://enterprise.github.com/aws/gov-cloud
+redirect_to: "https://enterprise.github.com/aws/gov-cloud"
 ---


### PR DESCRIPTION
redirect_to takes a string, not an array. that also makes total sense.