### PR TITLE
added OpenProcure.us

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -232,6 +232,7 @@ Code For America:
   - opendatastl
   - openkawasaki
   - openlexington
+  - openprocure
   - opennebraska
   - openoakland
   - opensaltlake


### PR DESCRIPTION
added https://github.com/munirent/openprocure to the list.  Hopefully it was in the appropriate place.