### PR TITLE
Remove extra link to the Community join app

### DIFF
--- a/index.html
+++ b/index.html
@@ -164,7 +164,7 @@ permalink: /
       <div class="mb-4 col-md-6 float-left">
         <h3 class="alt-h3 mb-2">Join the Peer Group</h3>
         <p class="text-gray">Join the <a href="https://government-community.githubapp.com/">semi-private group</a> of government employees using GitHub to share best practices for software collaboration.</p>
-        <p class="text-gray">You will <a href="https://government-community.githubapp.com/">have access</a> once the government email associated with your account is verified.
+        <p class="text-gray">You will have access once the government email associated with your account is verified.
       </div>
       <div class="mb-4 col-md-6 float-left">
         <h3 class="alt-h3 mb-2">Learn More</h3>


### PR DESCRIPTION
Flagged by WebAmin since they are adjacent and go to the same link
http://webaim.org/standards/wcag/checklist#sc2.4.4