### PR TITLE
Update governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -394,7 +394,6 @@ U.K. Central:
   - dvla
   - dvsa
   - EnvHack2
-  - EnvironmentAgency
   - GCHQ
   - gds-attic
   - gds-dead


### PR DESCRIPTION
Remove Environment Agency as all github repos are under Defra organisation now.