### PR TITLE
fix: Jekyl renamed `gems` to `plugins`

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,7 +9,7 @@ analytics_account: "UA-3769691-28"
 # build settings
 exclude: ["script", "vendor", "bower.json", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "package.json"]
 markdown: kramdown
-gems:
+plugins:
   - jekyll-avatar
   - jekyll-redirect-from
   - jekyll-seo-tag


### PR DESCRIPTION
Currently there is a Depreciation message in the build for this