### PR TITLE
Removed unavailable ibamacsr and readded new one

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -55,6 +55,7 @@ Bolivia:
 Brazil:
   - bacendeinf
   - camaradosdeputadosoficial
+  - cenima-ibama
   - cislgov
   - culturagovbr
   - dadosgovbr

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -64,7 +64,6 @@ Brazil:
   - gabinetedigital
   - govbr
   - GovBrasil
-  - ibamacsr
   - imagov
   - InstitutoBenjaminConstant
   - interlegis


### PR DESCRIPTION
Organization "ibamacsr" is 404 type of github organization. New one is "cenima-ibama" https://github.com/cenima-ibama (Centro Nacional de Monitoramento e Informações Ambientais)