### PR TITLE
chore: cleanup gem dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,18 +2,13 @@
 
 source 'https://rubygems.org'
 
-gem 'coffee-script'
-gem 'coffee-script-source'
 gem 'github-pages'
-gem 'jekyll-avatar'
 gem 'jekyll-octicons'
-gem 'rake'
 
 group :development, :test do
   gem 'html-proofer'
-  gem 'octokit'
   gem 'parallel'
-  gem 'pry'
+  gem 'rake'
   gem 'rubocop'
   gem 'typhoeus'
 end


### PR DESCRIPTION
Moved rake into the dev dependencies, and removed all gems that are
already covered by the “github-pages” gem dependency