### PR TITLE
Fix a11y skipped headers and missing link text

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,6 +8,7 @@
           </ul>
 
           <a href="/" class="text-center">
+            <span class="sr-only">Back to Home</span>
             {% octicon mark-github height:24 class:"fill-gray-light d-inline" aria-label:github-logo %}
           </a>
 

--- a/_includes/org-table.html
+++ b/_includes/org-table.html
@@ -1,14 +1,14 @@
 <div class="">
   <div class="org-include" id="include-{{ include.id }}">
 
-    <h3 class="alt-h2 mb-3" id="{{ include.id }}">{{ include.name }}</h3>
-    <h6 class="no-matches">No matches.</h6>
+    <h2 class="alt-h2 mb-3" id="{{ include.id }}">{{ include.name }}</h2>
+    <span class="no-matches">No matches.</span>
 
     {% assign columns = 4 %}
     {% for type_hash in include.orgs %}
       {% assign slug = type_hash[0] | downcase | replace: ' ','-' | replace: '.','' %}
       <div class="org-type clearfix" id="type-{{ slug }}">
-        <h4 class="alt-h3 mb-3" id="{{ slug }}">{{ type_hash[0] }} ({{ type_hash[1] | size }})</h4>
+        <h3 class="alt-h3 mb-3" id="{{ slug }}">{{ type_hash[0] }} ({{ type_hash[1] | size }})</h3>
 
         <div class="orgs">
           {% for org in type_hash[1] %}

--- a/community.md
+++ b/community.md
@@ -5,9 +5,10 @@ description: Government agencies at the national, state, and local level use Git
 permalink: /community/
 ---
 <div id="to-top" class="text-center border-top border-bottom mb-3 mb-md-5">
-  <h4 class="alt-h3 py-3 py-md-5">
+  <div class="alt-h3 py-3 py-md-5">
+    <label for="filter" class="sr-only">Search for civic hackers or research lists</label>
     <input id="filter" type="text" class="" placeholder="Type to search..."> or jump to the <a href="#civic_hackers">civic hackers</a> or <a href="#research">research</a> lists.
-  </h4>
+  </div>
 </div>
 
 {% include org-table.html orgs=site.data.governments id="governments" name="Governments" %}

--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -305,7 +305,7 @@ data:
 
 {% for section in page.data %}
 <div class="border-top mt-4 mt-md-6 pt-4 alt-h3 mb-3" markdown="1">
-### {{ section[0] }}
+## {{ section[0] }}
 </div>
 
   {% if section[1].product %}

--- a/index.html
+++ b/index.html
@@ -9,68 +9,68 @@ permalink: /
 <section class="container-lg p-responsive py-5 py-md-6 my-lg-6">
   <div class="clearfix gutter-spacious">
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon terminal height:28 class:"fill-blue d-inline mr-2" aria-label:terminal %}
         Collaborate on code
-      </h3>
+      </h2>
       <p class="text-gray">Code collaboration and review are built into the development process with GitHub. Share work, discuss changes, and get feedback in one place to write quality code.</p>
     </div>
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon server height:28 class:"fill-blue d-inline mr-2" aria-label:server %}
         On your servers or in the cloud
-      </h3>
+      </h2>
       <p class="text-gray">Run GitHub Enterprise on your servers as a virtual appliance, on AWS GovCloud or Azure, or let us host the code for you on GitHub.com, whatever your security requires.</p>
     </div>
   </div>
 
   <div class="clearfix gutter-spacious">
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon beaker height:28 class:"fill-blue d-inline mr-2" aria-label:beaker %}
         Foster innovation at your agency
-      </h3>
+      </h2>
       <p class="text-gray">GitHub enables you to easily accept, continuously test, and rapidly deploy new ideas to build better software, faster.</p>
     </div>
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon tools height:28 class:"fill-blue d-inline mr-2" aria-label:tools %}
         Software built your way
-      </h3>
+      </h2>
       <p class="text-gray">Integrate third party tools, from project management to continuous integration, to build software in the way that works best for your agency.</p>
     </div>
   </div>
 
   <div class="clearfix gutter-spacious">
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon code height:28 class:"fill-blue d-inline mr-2" aria-label:code %}
         InnerSource inside your agency
-      </h3>
+      </h2>
       <p class="text-gray">Build your agency’s software the way open source maintainers build theirs. Transparency and code reuse can help your team build better code.</p>
     </div>
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon lock height:28 class:"fill-blue d-inline mr-2" aria-label:lock %}
         Enterprise controls that agencies need
-      </h3>
+      </h2>
       <p class="text-gray">Encourage teams to work together while providing essential controls for employees and contractors alike using organizations and LDAP or CAS.</p>
     </div>
   </div>
 
   <div class="clearfix gutter-spacious">
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon globe height:28 class:"fill-blue d-inline mr-2" aria-label:globe %}
         Public engagement, developer community
-      </h3>
+      </h2>
       <p class="text-gray">Engage with 17 million developers using GitHub. Publish open source software on GitHub.com. Onboard, train, and recruit developers with ease.</p>
     </div>
     <div class="mb-3 mb-md-5 col-md-6 float-left">
-      <h3 class="alt-h3 mb-2">
+      <h2 class="alt-h3 mb-2">
         {% octicon checklist height:28 class:"fill-blue d-inline mr-2" aria-label:checklist %}
         Skip the paperwork
-      </h3>
+      </h2>
       <p class="text-gray">GitHub.com's terms of service are approved by the GSA and most plans fall below the micro-purchase threshold. Purchase GitHub Enterprise with major government acquisition schedules.</p>
     </div>
   </div>


### PR DESCRIPTION
From the conversation [here](https://github.com/github/government.github.com/issues/583), this PR does the following:

On the homepage updates the **h3**'s to **h2**'s while maintaining their classes for styling. 

On Accessibility switching section headers to **h2**'s instead of an **h3**

On Community removing the **h6** from the no matches, as it's not really a header for a section. Setting the **h3**'s to **h2**'s and their sub heading from an **h4** to **h3**. 

Also on Community, I also removed the **h4** around the input as it wasn't a header, replacing it with a div and a screen reader only label. 

Across the site, in the Footer I updated the octocat link to have a screen reader only "Back to Home" text to address missing text in the link. Since the svgs are loaded through a node module, I couldn't apply a title to the svg and reference it with aria-labelledby.

One thing I didn't fix was the contrast issue on the accessibility page. In the tables, Wave is reporting the text may not meet contrast requirements, but a purely technical fix took away from design aesthetics, so I decided not to attempt them without some direction. 