### PR TITLE
Add ontario-digital to Canadian Government Orgs

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -124,6 +124,7 @@ Canada:
   - nrc-cnrc
   - NRCan
   - nsgov
+  - OntarioDigital
   - open-data
   - phac-nml
   - pspc-spac


### PR DESCRIPTION
@ontario-digital is currently a user account instead of an Org. Just opening this one up to see if they'll convert it :wink: 

If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/