### PR TITLE
chore: Remove codeforraleigh

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -70,6 +70,7 @@ Civic Hackers:
   - myanmarapi
   - mysociety
   - nationaldayofcivichacking
+  - ncopenpass
   - netzwerkrecherche
   - npp
   - nrgi

--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -214,7 +214,6 @@ Code For America:
   - codeforpg
   - codeforphilly
   - codeforportland
-  - codeforraleigh
   - codeforrockford
   - codeforrva
   - codeforsanjose


### PR DESCRIPTION
Organization appears to be gone and is breaking the build