### PR TITLE
added link to PDF rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ permalink: /
   <div class="container-lg p-responsive py-5 py-md-6 ">
 
     <h2 class="alt-h2 text-center mb-3 mt-lg-6" id="more-than-just-code">More than just code</h2>
-    <p class="alt-lead text-gray text-center col-md-10 mx-auto">Agencies use GitHub to engage developers and collaborate with the public on open source, open data and open government efforts. GitHub even renders common formats like <a href="https://github.com/blog/1784-rendered-prose-diffs">text</a>, <a href="https://help.github.com/articles/rendering-csv-and-tsv-data">CSV</a>, PDF, <a href="https://help.github.com/articles/mapping-geojson-files-on-github">geospatial data</a> and Jupyter Notebooks.</p>
+    <p class="alt-lead text-gray text-center col-md-10 mx-auto">Agencies use GitHub to engage developers and collaborate with the public on open source, open data and open government efforts. GitHub even renders common formats like <a href="https://github.com/blog/1784-rendered-prose-diffs">text</a>, <a href="https://help.github.com/articles/rendering-csv-and-tsv-data">CSV</a>, <a href="https://github.com/blog/1974-pdf-viewing">PDF</a>, <a href="https://help.github.com/articles/mapping-geojson-files-on-github">geospatial data</a> and Jupyter Notebooks.</p>
 
     <div class="my-4 my-lg-6 clearfix gutter-spacious">
       <div class="col-md-4 float-left animate-out mb-4">


### PR DESCRIPTION
Like the rest of the formats on this list, now PDF also has a link to a github
page talking about its renderer.