### PR TITLE
Remove openregister from civic_hackers

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -106,7 +106,6 @@ Civic Hackers:
   - opennorth-archive
   - openopps
   - openplans
-  - openregister
   - openstate
   - openstates
   - opented


### PR DESCRIPTION
Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: openregister
**GitHub Organization url**: https://github.com/openregister  
**Country/Locality**: UK

Inclusion requirements:
- [ ] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [ ] If this is a government project, your Organization's description should include a reference to your country/agency.
- [ ] Make sure your Organization includes at least one public repository
- [ ] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
