### PR TITLE
Fix repeating logos & scroll bug

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,12 +136,7 @@ permalink: /
       {% endfor %}
     </div>
   </div>
-
-<div class="full-screen featured-orgs">
-  {% for org in site.featured_orgs %}
-  <a href="https://github.com/{{ org }}" class="animate-in">{% avatar user=org size=80 %}</a>
-  {% endfor %}
-</div>
+</section>
 
 <section id="get-started" class="mini-section mt-6">
   <div class="container-lg p-responsive">


### PR DESCRIPTION
@kimestoesta noticed that the homepage had a horizontal scroll bug: 

![image](https://user-images.githubusercontent.com/527589/38278288-0a065b9e-3761-11e8-8936-94b006fd67d4.png)

While debugging this, I noticed that the community logos matrix was shown twice:

![image](https://user-images.githubusercontent.com/527589/38278327-2da35c32-3761-11e8-84a4-c9aabb216f9b.png)

This PR fixes both.