### PR TITLE
lazy-load the avatars on the community page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,8 @@ source 'https://rubygems.org'
 
 gem 'github-pages'
 gem 'jekyll-octicons'
+# need lazy-load support
+gem 'jekyll-avatar', '>= 0.6.0'
 
 group :development, :test do
   gem 'html-proofer'

--- a/_includes/org-table.html
+++ b/_includes/org-table.html
@@ -20,7 +20,7 @@
 
             <div class="col-sm-3 float-left org">
               <a href="https://github.com/{{ org }}" title="{{ org }}" class="border d-block text-center px-2 py-4 mb-4">
-                {% avatar user=org size=60 %}
+                {% avatar user=org size=60 lazy=true %}
                 <div class="org-name text-small">
                   @{{ org }}
                 </div>

--- a/_layouts/support-page.html
+++ b/_layouts/support-page.html
@@ -11,4 +11,15 @@
     {{ content }}
   </div>
 
+<!-- https://www.andreaverlicchi.eu/lazyload/ -->
+<script type="text/javascript">
+  (function (w, d) {
+    var b = d.getElementsByTagName('body')[0];
+    var s = d.createElement("script"); s.async = true;
+    var v = !("IntersectionObserver" in w) ? "8.8.0" : "10.9.0";
+    s.src = "https://cdnjs.cloudflare.com/ajax/libs/vanilla-lazyload/" + v + "/lazyload.min.js";
+    w.lazyLoadOptions = {};
+    b.appendChild(s);
+  }(window, document));
+</script>
 {% include footer.html %}


### PR DESCRIPTION
Closes #664.

Lazy-loads the images for a dramatically faster page load speed. Before:

<img alt="screen shot 2018-03-31 at 10 59 03 am" src="https://user-images.githubusercontent.com/86842/38164576-b6cc1876-34d4-11e8-9b2d-9d075e781ecd.png">

After:

<img alt="screen shot 2018-03-31 at 10 58 19 am" src="https://user-images.githubusercontent.com/86842/38164577-bcf0141e-34d4-11e8-8e2e-924602edbd1d.png">

Waiting on jekyll-avatar to be updated on GitHub Pages.

cc @benbalter 