### PR TITLE
chore: Remove deleted org gds-attic

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -432,7 +432,6 @@ U.K. Central:
   - dvla
   - dvsa
   - GCHQ
-  - gds-attic
   - gds-dead
   - gds-operations
   - guidance-guarantee-programme


### PR DESCRIPTION
The org appears to be removed