### PR TITLE
Hide Fedramp pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ relative_permalinks: false
 analytics_account: "UA-3769691-28"
 
 # build settings
-exclude: ["script", "vendor", "bower.json", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "package.json", "node_modules"]
+exclude: ["script", "vendor", "bower.json", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "package.json", "node_modules", "fedramp.md", "fedramp-confirmation.md"]
 markdown: kramdown
 plugins:
   - jekyll-avatar

--- a/index.html
+++ b/index.html
@@ -5,19 +5,6 @@ description: Make government better, together. Stories of open source, open data
 org_count: 60
 permalink: /
 ---
-<div class="container-lg p-responsive " style="display:none;">
-  <div class="Box clearfix p-4 p-sm-5 col-md-7 mx-auto mt-6">
-    <div class="float-left">
-      <img class="d-block pr-4" style="width: 80px;" alt="FedRAMP Logo" src="{{"/assets/img/Fedramp-logo.svg" | relative_url}}">
-    </div>
-    <div class="overflow-hidden">
-      <p>GitHub is now Federal Risk and Authorization Management Program (FedRAMP) authorized.
-      </p>
-      <a href="{{"/fedramp/" | relative_url}}">Learn More {% octicon chevron-right height:18 class:"d-inline fill-blue ml-1" %}</a>
-    </div>
-  </div>
-</div>
-
 <section class="container-lg p-responsive py-5 py-md-6 my-lg-6">
   <div class="clearfix gutter-spacious">
     <div class="mb-3 mb-md-5 col-md-6 float-left">


### PR DESCRIPTION
This PR removes https://government.github.com/fedramp/ from the site. To add it back in, just remove it from the exclude list.

Slack context: https://github.slack.com/archives/C3MUZQ7EZ/p1534439486000100
PR that added it: https://github.com/github/government.github.com/pull/671

cc/ @SRosenberg13 @mike421453 @jbjonesjr 

