### PR TITLE
Fix errors causing build to fail the rubocop checks.

### DIFF
--- a/script/ensure-orgs
+++ b/script/ensure-orgs
@@ -41,6 +41,7 @@ files.each do |file|
   data.each do |group, orgs|
     not_orgs = Parallel.map(orgs) { |org| org unless org?(org) }.compact
     next if not_orgs.empty?
+
     puts "\nIn #{File.basename(file)}, in the #{group} group, the following entries are users, not orgs:\n\n"
     puts not_orgs
     valid = false

--- a/script/fetch-us
+++ b/script/fetch-us
@@ -27,6 +27,7 @@ orgs = orgs['results'].collect { |data| data['account'] }
 orgs.each do |org|
   next if existing.include?(org.downcase)
   next unless org_exists? org
+
   org_file['U.S. Federal'].push(org.downcase)
 end
 


### PR DESCRIPTION
This is causing all PRs to fail since #715. Currently affects PRs #715, #717, #718, #720, #721, #722, #723, and #724.

The root cause is likely https://github.com/rubocop-hq/rubocop/pull/6235, which turned on a check that used to be disabled by default.