### PR TITLE
Fedramp lead show

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,7 +7,7 @@ relative_permalinks: false
 analytics_account: "UA-3769691-28"
 
 # build settings
-exclude: ["script", "vendor", "bower.json", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "package.json", "node_modules", "fedramp.md", "fedramp-confirmation.md"]
+exclude: ["script", "vendor", "bower.json", "Gemfile", "Gemfile.lock", "Rakefile", "readme.md", "package.json", "node_modules"]
 markdown: kramdown
 plugins:
   - jekyll-avatar

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@ description: Make government better, together. Stories of open source, open data
 org_count: 60
 permalink: /
 ---
-<div class="container-lg p-responsive ">	
+<div class="container-lg p-responsive">	
   <div class="Box clearfix p-4 p-sm-5 col-md-7 mx-auto mt-6">
     <div class="float-left">
       <img class="d-block pr-4" style="width: 80px;" alt="FedRAMP Logo" src="{{"/assets/img/Fedramp-logo.svg" | relative_url}}">

--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@ description: Make government better, together. Stories of open source, open data
 org_count: 60
 permalink: /
 ---
+<div class="container-lg p-responsive ">	
+  <div class="Box clearfix p-4 p-sm-5 col-md-7 mx-auto mt-6">
+    <div class="float-left">
+      <img class="d-block pr-4" style="width: 80px;" alt="FedRAMP Logo" src="{{"/assets/img/Fedramp-logo.svg" | relative_url}}">
+    </div>
+    <div class="overflow-hidden">
+      <p>GitHub is now Federal Risk and Authorization Management Program (FedRAMP) authorized.
+      </p>
+      <a href="{{"/fedramp/" | relative_url}}">Learn More {% octicon chevron-right height:18 class:"d-inline fill-blue ml-1" %}</a>
+    </div>
+  </div>
+</div>
+
 <section class="container-lg p-responsive py-5 py-md-6 my-lg-6">
   <div class="clearfix gutter-spacious">
     <div class="mb-3 mb-md-5 col-md-6 float-left">


### PR DESCRIPTION
This PR includes two updates to add FedRAMP back to government.github.com

1. Add form page and form thank you pages back
2. Add the box back to the home page

We are now FedRAMP authorized!

cc: @SRosenberg13 @sophshep @courtneyscharff 

