### PR TITLE
Remove GENIEMC

### DIFF
--- a/_data/research.yml
+++ b/_data/research.yml
@@ -30,7 +30,6 @@ U.S. Research Labs:
   - esgf
   - exmatex
   - flux-framework
-  - GENIEMC
   - globus
   - glvis
   - HipGISAXS


### PR DESCRIPTION
GENIEMC is now GENIE-MC-Community, but can't verify it's relationship at this point

Fixes the build