### PR TITLE
Add the French Alternative Energies and Atomic Energy Commission (CEA)

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -220,6 +220,10 @@ France:
   - ANSSI-FR
   - ApieFrance
   - betagouv
+  - cea-hpc
+  - cea-leti
+  - cea-list
+  - cea-sec
   - clipos
   - clipos-archive
   - communaute-cimi


### PR DESCRIPTION
See [www.cea.fr](http://www.cea.fr/english).

The four organizations have been added to the official list maintained
by the DISIC (see DISIC/politique-de-contribution-open-source#116).

Hope this helps.