### PR TITLE
chore: Remove custom libcurl config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,20 +7,9 @@ env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
-addons:
-  apt:
-    packages:
-    - libcurl4-openssl-dev # required to avoid SSL errors
-
 branches:
   only:
     - gh-pages
     - /.*/
 
-before_install:
-- openssl version
-- openssl ciphers -v
-- openssl s_client -cipher ECDHE-RSA-AES256-GCM-SHA384 -connect github.blog:443 -tls1_2
-- curl -sSL -D - https://github.blog/2014-02-14-rendered-prose-diffs/ -o /dev/null
-sudo: false
 cache: bundler


### PR DESCRIPTION
Travis was hitting some errors on the last build. It looks like this also predated Travis updating the base image to xenial