### PR TITLE
Add missing UK National Health Service orgs

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -519,6 +519,7 @@ The Netherlands:
   - zaanstad
 
 U.K. Central:
+  - 111online
   - alphagov
   - BEACmodel
   - britishlibrary
@@ -563,6 +564,9 @@ U.K. Central:
   - naouk
   - nationalarchives
   - NationalCrimeAgency
+  - nhsconnect
+  - nhsdigital
+  - nhsengland
   - nhsuk
   - OfqualGovUK
   - ONSdigital

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -730,7 +730,7 @@ U.S. Federal:
   - doecode
   - EEOC
   - energyapps
-  - erdc-cm
+  - erdc
   - eregs
   - fcc
   - fda


### PR DESCRIPTION
This commit adds four missing UK National Health Service organisations.
