### PR TITLE
Add eAbsentee to civic_hackers.yml

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -42,6 +42,7 @@ Civic Hackers:
   - dssg
   - dutsec
   - dxw
+  - eAbsentee
   - e-government-ua
   - edgi-govdata-archiving
   - electionleaflets


### PR DESCRIPTION
See https://github.com/eAbsentee/eAbsentee and https://www.eabsentee.org/.

**Your Organization**: eAbsentee
**GitHub Organization URL**: @eAbsentee 
**Country/Locality**: Virginia, United States

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
CC @rau and @lrouvelas