### PR TITLE
Add cloud-gov to US Federal organizations

### DIFF
--- a/404.md
+++ b/404.md
@@ -6,9 +6,3 @@ title: Not found
 <p class="text-center alt-lead">
   The page you're looking for doesn't seem to be there!
 </p>
-
-<script>
-  var GOOG_FIXURL_LANG = "en";
-  var GOOG_FIXURL_SITE = "{{ site.url }}";
-</script>
-<script src="//linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -721,6 +721,7 @@ U.S. Federal:
   - CDCgov
   - cfpb
   - cisagov
+  - cloud-gov
   - cmsgov
   - commercedataservice
   - commercegov


### PR DESCRIPTION
@cloud-gov recently split our github org out from @18F - this update adds us our org to the US Federal list

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _cloud.gov_  
**GitHub Organization url**: _cloud-gov_  
**Country/Locality**: _USA_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
