### PR TITLE
Remove "SLO-County-Planning-Building" org

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -717,7 +717,6 @@ U.S. County:
   - saccounty
   - sfcta
   - SJCGIS
-  - SLO-County-Planning-Building
   - slugis
 
 U.S. Federal:


### PR DESCRIPTION
There is no public GitHub org called "SLO-County-Planning-Building". If this file is not intended to be limited to public-only, disregard