### PR TITLE
Remove "usinterior" org

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -859,7 +859,6 @@ U.S. Federal:
   - USGS-R
   - USGS-WiM
   - usindianaffairs
-  - usinterior
   - usnationalarchives
   - USPS
   - USPTO


### PR DESCRIPTION
There is no public GitHub org with the name "usinterior"
