### PR TITLE
Added Statistics Sweden to the list.

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -494,6 +494,7 @@ Sweden:
   - SodertornHB
   - statens-maritima-museer
   - Statenspersonadressregister
+  - statisticssweden
   - Sundsvallskommun
   - sverigesradio
   - SVT


### PR DESCRIPTION
Statistics Sweden is a Swedish government agency that brings official statistics of Sweden to the public

**Your Organization**: Statistics Sweden
**GitHub Organization url**: @statisticssweden
**Country/Locality**: Sweden

