### PR TITLE
re-add US Dept of Interior in different org

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -742,6 +742,7 @@ U.S. Federal:
   - didsr
   - digital-analytics-program
   - doecode
+  - DOIOSS
   - EEOC
   - energyapps
   - erdc


### PR DESCRIPTION
DOIOSS seems to be the org now; previous removed in https://github.com/github/government.github.com/commit/ab0263b07099455a4933a7d4788927959488c79d

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _US Dept of Interior_  
**GitHub Organization url**: _@DOIOSS_  
**Country/Locality**: _US_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
