### PR TITLE
added klucznicy

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -72,6 +72,7 @@ Civic Hackers:
   - infoculture
   - italia
   - justopensource
+  - klucznicy
   - koelnapi
   - lisbon-opendata
   - localdata


### PR DESCRIPTION
Klucznicy is a Polish NGO & think tank based in Poznan, Poland, focused on transparency and introducing SMART goals in local (city) government.

**Your Organization**: _Stowarzyszenie Klucznicy_  
**GitHub Organization url**: _@klucznicy_  
**Country/Locality**: _Poznan, Poland_

Homepage (Polish only): https://klucznicy.org.pl/

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.