### PR TITLE
Add Specialist Unit for Open Government Data Canton of Zurich, Switzerland

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -519,6 +519,7 @@ Switzerland:
   - gisktzh
   - kanton-bern
   - ogdch
+  - openZH
   - sitn
 
 The Netherlands:


### PR DESCRIPTION
**Your Organization**: _Specialist Unit for Open Government Data Canton of Zurich_  
**GitHub Organization url**: _@openZH_  
**Country/Locality**: _Canton of Zurich, Switzerland

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.

Thanks, best a