### PR TITLE
Add Technologiestiftung Berlin

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -147,6 +147,7 @@ Civic Hackers:
   - sunlightlabs
   - sunlightpolicy
   - teampopong
+  - technologiestiftung
   - teplitsa
   - tfrce
   - thacker


### PR DESCRIPTION
Adding the Technologiestiftung Berlin, a non-profit foundation, to the list of civic hacker organizations

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _Technologiestiftung Berlin_  
**GitHub Organization url**: _@technologiestiftung_  
**Country/Locality**: _Berlin, Germany_

**Technologiestiftung Berlin**
https://www.technologiestiftung-berlin.de/de/startseite/ 

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
