### PR TITLE
Add Georgia EPD IT under U.S. States organizations

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -105,7 +105,6 @@ Canada:
   - AAFC-MBB
   - abgov
   - bac-lac
-  - bcdevexchange
   - BCGov
   - canada-ca
   - cds-snc
@@ -126,6 +125,7 @@ Canada:
   - electionsquebec
   - esdc-devx
   - esdc-edsc
+  - ExchangeBC
   - fgpv-vpgf
   - gc-proto
   - GCTC-NTGC

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -936,6 +936,7 @@ U.S. States:
   - DCGovWeb
   - eHawaii
   - FGS-FloridaGeologicalSurvey
+  - gaepdit
   - gocodecolorado
   - IDAHO-DOC-NCOMS
   - idahofishgame


### PR DESCRIPTION
**Your Organization**: _Georgia Environmental Protection Division_  
**GitHub Organization url**: _@gaepdit_  
**Country/Locality**: _Georgia, U.S._

 :heart: GitHub Government Contributors
