### PR TITLE
Add margin for cities images

### DIFF
--- a/index.html
+++ b/index.html
@@ -149,7 +149,7 @@ permalink: /
         {% assign count = count | plus:1 %}
       {% endfor %}
     {% endfor %}
-    <div class="featured-orgs text-center p-2">
+    <div class="featured-orgs text-center p-2 m-2">
       {% for org in site.featured_orgs %}
       <a href="https://github.com/{{ org }}" class="animate-in">{% avatar user=org size=80 %}</a>
       {% endfor %}


### PR DESCRIPTION
Add margins for responsive design, when you resize your browser can see this section overlap the screen and appear scrollbar at x.