### PR TITLE
Add the Department of Conservation to NZ Government

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -360,6 +360,7 @@ New Zealand:
   - CanterburyRegionalCouncil
   - data-govt-nz
   - DigitalNZ
+  - docgovtnz
   - ElectricityAuthority
   - GOVTNZ
   - linz


### PR DESCRIPTION
Propose adding the Department of Conservation (doc.govt.nz) to the list of New Zealand Government entities on GitHub

**Your Organization**:  Department of Conservation | Te Papa Atawhai
**GitHub Organization url**: @docgovtnz 
**Country/Locality**: New Zealand

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
