### PR TITLE
Correct openglasgow

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -608,7 +608,6 @@ U.K. Central:
   - nihp-public
   - OfqualGovUK
   - ONSdigital
-  - openglasgow
   - openregister
   - osgeouk
   - scottishgovernment
@@ -642,6 +641,7 @@ U.K. Councils:
   - lichfield-district-council
   - LondonBoroughSutton
   - LutonCouncil
+  - openglasgow
   - RotherDC
   - RoyalBoroughKingston
   - surreydigitalservices


### PR DESCRIPTION
@openglasgow is run by Glasgow City Council, not UK Central government. This PR moves it to the correct section.