### PR TITLE
Added three Russian orgs

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -438,6 +438,11 @@ Romania:
   - govro
   - MinistryOfLabor
 
+Russia:
+  - cikrf
+  - kznru
+  - moscow-technologies
+
 Saudi Arabia:
   - SAS-NCDC
 


### PR DESCRIPTION
Added three government orgs in Russia with source code open:
- CIK RF - Central election comission - https://cikrf.ru
- kznru - Kazan city government - http://kzn.ru/
- moscow-technologies - Moscow city government, department of IT - https://www.mos.ru/dit/

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _ACME Agency_  
**GitHub Organization url**: _@acmeagency_  
**Country/Locality**: _Alberta, Canada_

Inclusion requirements:
- [X ] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [ X] If this is a government project, your Organization's description should include a reference to your country/agency.
- [ X] Make sure your Organization includes at least one public repository
- [ X] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
