### PR TITLE
Add @section77 to list of Civic Hacking organizations

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -138,6 +138,7 @@ Civic Hackers:
   - redciudadana
   - ropengov
   - safecast
+  - section77
   - security-force-monitor
   - smartchicago
   - smcgov


### PR DESCRIPTION
Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _Section77 e.V._  
**GitHub Organization url**: _@section77_  
**Country/Locality**: Offenburg, Germany_

Inclusion requirements:
- [X] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [X] If this is a government project, your Organization's description should include a reference to your country/agency.
- [X] Make sure your Organization includes at least one public repository
- [X] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
