### PR TITLE
Update CI status badge

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# GitHub and Government [![Build Status](https://travis-ci.org/github/government.github.com.svg?branch=gh-pages)](https://travis-ci.org/github/government.github.com)
+# GitHub and Government [![Test site build](https://github.com/github/government.github.com/actions/workflows/build.yml/badge.svg)](https://github.com/github/government.github.com/actions/workflows/build.yml)
 
 ![screenshot](assets/img/screenshot.png)
 


### PR DESCRIPTION
CIs have been migrated to GitHub Actions in #802, so this PR updates CI status badge on readme.md.
