### PR TITLE
Add gazeti to Civic Hackers

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -58,6 +58,7 @@ Civic Hackers:
   - everypolitician
   - everypolitician-scrapers
   - friendlycode
+  - gazeti
   - girlscodingkosova
   - goc-spending
   - govex


### PR DESCRIPTION
Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _gazeti.AFRICA_  
**GitHub Organization url**: _@gazeti_  
**Country/Locality**: _South Africa_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
