### PR TITLE
add California water board org

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -967,6 +967,7 @@ U.S. States:
   - AlaskaDHSS
   - azgs
   - calsimcallite
+  - CAWaterBoardDataCenter
   - ccap
   - coloradodemography
   - CTOpenData


### PR DESCRIPTION
California Water Board is an active open source github page for developers at the Water Board.

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _ACME Agency_  
**GitHub Organization url**: _@acmeagency_  
**Country/Locality**: _Alberta, Canada_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
