### PR TITLE
Add TechToTheRescue to civic_hackers.yml

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -150,6 +150,7 @@ Civic Hackers:
   - sunlightpolicy
   - teampopong
   - technologiestiftung
+  - techtotherescue
   - teknologi-pendidikan
   - teplitsa
   - tfrce


### PR DESCRIPTION
Tech To The Rescue is a global platform that matches IT companies and non-profit organizations to implement pro bono technology solutions to solve the world's most pressing problems: http://techtotherescue.org

**Your Organization**: TechToTheRescue  
**GitHub Organization url**: [github.com/techtotherescue](https://github.com/techtotherescue)  
**Country/Locality**: Global

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User.
- [n/a] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.

