### PR TITLE
Add South Korea

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -142,6 +142,7 @@ Civic Hackers:
   - security-force-monitor
   - smartchicago
   - smcgov
+  - southkorea
   - spaceadvocates
   - spaghetti-open-data
   - stadtlandcode


### PR DESCRIPTION
**Your Organization**: _South Korea_  
**GitHub Organization url**: _@southkorea_  
**Country/Locality**: _Seoul, South Korea_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [ ] Please also include a URL for your organization that links back to your organization or agency homepage.
  
 :heart: GitHub Government Contributors
