### PR TITLE
Remove deleted organizations

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -155,7 +155,6 @@ Civic Hackers:
   - teknologi-pendidikan
   - teplitsa
   - tfrce
-  - thacker
   - theodi
   - tulsawebdevs
   - unitedstates
@@ -188,7 +187,6 @@ Code For America:
   - betanyc
   - blue-sky-skunkworks
   - bmghack
-  - c4gnv
   - caciviclab
   - censusreporter
   - cforlando

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -964,7 +964,6 @@ U.S. Military and Intelligence:
   - nsacyber
   - project-interoperability
   - psns-imf
-  - screamlab
   - shareandprotect
   - SIMP
   - transcom


### PR DESCRIPTION
Remove the deleted account in data:
```bash
Checking that all orgs listed are in fact, an org...

In civic_hackers.yml, in the Civic Hackers group, the following entries are users, not orgs:

thacker

In civic_hackers.yml, in the Code For America group, the following entries are users, not orgs:

c4gnv

In governments.yml, in the U.S. Military and Intelligence group, the following entries are users, not orgs:

screamlab
```