### PR TITLE
Fix link for showcases

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@ permalink: /
     </div>
 
     <p class="text-center">
-      <a href="https://github.com/showcases" class="btn btn-outline">See more showcases &rarr;</a>
+      <a href="https://github.com/collections/government" class="btn btn-outline">See more showcases &rarr;</a>
     </p>
 
   </div>


### PR DESCRIPTION
I think linking the GitHub Government collection does make more sense in this case.