### PR TITLE
Improve height of showcase tiles

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -60,6 +60,8 @@ body {
   transition: all 0.6s ease-in-out 0s;
   -webkit-transform: translateZ(0);
   transform: translateZ(0);
+  display: inline-block;
+  height: 100%;
 }
 
 .animate-out {


### PR DESCRIPTION
This PR sets the showcase tiles to 100% which will make it easier to click on the the actual link.

Before:
![image](https://github.com/github/government.github.com/assets/94064167/f88cecca-8254-4832-99d4-133d30b72109)


After:
![image](https://github.com/github/government.github.com/assets/94064167/268457ae-61fd-4da7-803f-a8719af13361)
