### PR TITLE
Remove orgs without profile picture

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -38,9 +38,9 @@ featured_orgs:
   - wet-boew
   - e-gob
   - City-of-Helsinki
-  - itschool
+  - ec-europa
   - linz
-  - govph
+  - BSI-Bund
   - commonwealth-of-puerto-rico
   - The-Municipality-of-Staffanstorp
   - malmostad
@@ -48,7 +48,7 @@ featured_orgs:
   - alv-ch
   - city-of-bloomington
   - cityofchattanooga
-  - cityofnewyork
+  - minvws
   - Honolulu
   - mnhrc
   - NYCComptroller
@@ -61,7 +61,7 @@ featured_orgs:
   - State-of-Arizona
   - alphagov
   - BarnsleyCouncil
-  - BristolCityCouncil
+  - nhsuk
   - cabinetoffice
   - datagovuk
   - dfid


### PR DESCRIPTION
I just removed the orgs that do not have a profile picture and replaced them with orgs that do have one.

This is what the list currently looks like:
![image](https://github.com/github/government.github.com/assets/94064167/36fdc682-5914-4f3b-a51a-1fe6ba010e6c)
