### PR TITLE
Fix link on Accessibility

### DIFF
--- a/docs/accessibility.md
+++ b/docs/accessibility.md
@@ -284,7 +284,7 @@ data:
         comments: "Documentation available at [government.github.com/accessibility](https://government.github.com/accessibility/)"
       - criterion: "(c) Support services for products shall accommodate the communication needs of end-users with disabilities."
         support: Supports
-        comments: "Support provided via [web](https://help.github.com) and [email](https://github.com/contactus)"
+        comments: "Support provided via [web](https://help.github.com) and [email](mailto:government@github.com)"
 ---
 
 <div class="col-md-8 mx-auto">


### PR DESCRIPTION
This PR replaces the previous link that lead to just a GitHub profile with the correct mailto: link.