### PR TITLE
Add ellipsis for overflow in .org-name

### DIFF
--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1,11 +1,11 @@
-// $blue: #2D86FB;
-
 body {
   font-family: 'Roboto', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-size: 16px;
 }
 
+//
 // HEADER
+//
 
 .page-header {
   width: 100%;
@@ -50,10 +50,18 @@ body {
   padding-bottom: 0;
 }
 
-.org-include .no-matches { display: none; }
+.org-include .no-matches { 
+  display: none; 
+}
 
-/* Animations */
-/* -------------------------------------------------------------------------- */
+.org-name {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+//
+// Animations
+//
 
 .animate-in {
   -webkit-transition: all 0.6s ease-in-out 0s;


### PR DESCRIPTION
This pull request adds an ellipsis when the .org-name string overflows.

Before:

![image](https://github.com/github/government.github.com/assets/94064167/f78e990a-cf7b-4915-b3fe-6bd05877ede0)

After:

![image](https://github.com/github/government.github.com/assets/94064167/39aadbca-d873-453f-a433-82d63de89202)
