### PR TITLE
Include Department of Information Technology of Taipei City Government on GitHub.

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -635,6 +635,7 @@ Taiwan:
   - moda-gov-tw
   - pdis
   - taipeicity
+  - taipei-doit
 
 Thailand:
   - DGA-Thailand


### PR DESCRIPTION
Dear Maintenance Team,

We are reaching out from the Taipei City Government's GitHub maintenance team to request the inclusion of the **Department of Information Technology, Taipei City Government** (@taipei-doit) in the Government Organizations section on GitHub.

Here are the details for your reference:

Detailed Information:
- Organization: Department of Information Technology, Taipei City Government
- GitHub Organization URL: @taipei-doit
- Country/Locality: Taipei, Taiwan
- Link: https://doit.gov.taipei/

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.