### PR TITLE
Add Various U.S. government GitHub orgs to the list

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -864,10 +864,13 @@ U.S. Federal:
   - cisagov
   - cloud-gov
   - cmsgov
+  - Code-dot-mil
   - commercedataservice
   - commercegov
   - demand-driven-open-data
   - department-of-veterans-affairs
+  - deptofdefense
+  - dhs-gov
   - didsr
   - digital-analytics-program
   - dodcio
@@ -885,6 +888,7 @@ U.S. Federal:
   - federal-courts-software-factory
   - federaltradecommission
   - fedspendingtransparency
+  - fema
   - firelab
   - globegit
   - gopleader
@@ -918,10 +922,13 @@ U.S. Federal:
   - nasaworldwind
   - NationalGuard
   - nationalparkservice
+  - nationalsecurityagency
   - navadmc
+  - NCI-Agency
   - NCRN
   - NeoGeographyToolkit
   - nesii
+  - ngageoint
   - ngds
   - nhanes
   - nidcd
@@ -933,6 +940,7 @@ U.S. Federal:
   - NOAA-ORR-ERD
   - noaa-pmel
   - ntia
+  - NUWCDIVNPT
   - ombegov
   - Open-Sat
   - opengovplatform
@@ -950,12 +958,14 @@ U.S. Federal:
   - SSAgov
   - state-hiu
   - sunpy
+  - transcom
   - us-bea
   - US-CBP
   - US-Department-of-the-Treasury
   - usagov
   - usaid
   - usajobs
+  - usarmyresearchlab
   - usasearch
   - usbr
   - uscensusbureau
@@ -991,6 +1001,7 @@ U.S. Federal:
   - USGS-R
   - USGS-WiM
   - usnationalarchives
+  - USNavalResearchLaboratory
   - usopm
   - USPS
   - USPTO


### PR DESCRIPTION
Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

> NOTE: This PR adds numerous organizations from within the Department of Homeland Security as well as a few others that can be found on code.gov (the US code metadata repository). If we need to only include DHS organizations I can modify the PR, but since these are publicly known via code.gov I think they should be good to include.

**Your Organization**: Department of Homeland Security
**GitHub Organization url**: @dhs-gov
**Country/Locality**: United States

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
