### PR TITLE
Remove Canada:MTS-STM

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -134,6 +134,7 @@ Canada:
   - cse-cst
   - CSPS-EFPC-DAAN
   - CybercentreCanada
+  - DTS-STN
   - ECCC-MSC
   - eodms-sgdot
   - esdc-devx

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -151,7 +151,6 @@ Canada:
   - LMID-DIMT
   - MC-MBO-WebPublishingTeam
   - MetPX
-  - MTS-STM
   - nrc-cnrc
   - NRCan
   - nsgov


### PR DESCRIPTION
@MTS-STM is an inactive/empty org with broken website link. Entry doesn't provide any value to this list.