### PR TITLE
Added Govt & CivicOrgs

### DIFF
--- a/_data/civic_hackers.yml
+++ b/_data/civic_hackers.yml
@@ -14,6 +14,7 @@ Civic Hackers:
   - chihacknight
   - ciudadanointeligente
   - civcoms
+  - civicactions
   - civic-commons
   - civicdata
   - civicninjas
@@ -50,6 +51,7 @@ Civic Hackers:
   - digitalstate
   - dobtco
   - drupal4gov
+  - dscoalition
   - dssg
   - dutsec
   - dxw

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -887,6 +887,7 @@ U.S. Federal:
   - Federal-Aviation-Administration
   - federal-courts-software-factory
   - federaltradecommission
+  - fedramp
   - fedspendingtransparency
   - fema
   - firelab
@@ -896,6 +897,7 @@ U.S. Federal:
   - GrainGenes
   - gsa
   - gsa-oes
+  - gsa-tts
   - hhs
   - HHS-AHRQ
   - HHSDigitalMediaAPIPlatform


### PR DESCRIPTION


I submitted a few orgs, deets below

**Your Organization**: CivicActions
**GitHub Organization url**: _@civicactions_
**Country/Locality**: United States
**URL** : [civicactions.com](https://civicactions.com/)

**Your Organization**: Digital Services Coalition
**GitHub Organization url**: _@dscoalition_  
**Country/Locality**: United States
**URL** : [digitalservicescoalition.org](https://digitalservicescoalition.org/)

I find it lolworthy that GitHub, who is FedRamp’d, didn’t have FedRamp as a govt org 😄
**Your Organization**: _FedRamp_  
**GitHub Organization url**: _@fedramp_  
**Country/Locality**: United States
**URL** : [fedramp.gov](https://www.fedramp.gov/)

**Your Organization**: _GSA Technology Transformation Services_  
**GitHub Organization url**: _@gsa-tts_  
**Country/Locality**: United States
**URL** : [gsa.gov](https://www.gsa.gov/about-us/organization/federal-acquisition-service/technology-transformation-services)

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: @TheBoatyMcBoatFace

cc: @grugnog 
