### PR TITLE
Update governments.yml to add the U.S. Internal Revenue Service public repos

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -911,7 +911,6 @@ U.S. Federal:
   - Innovation-Toolkit
   - internationaltradeadministration
   - ioos
-  - IRSgov
   - IRS-public
   - keplergo
   - libraryofcongress

--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -912,6 +912,7 @@ U.S. Federal:
   - internationaltradeadministration
   - ioos
   - IRSgov
+  - IRS-public
   - keplergo
   - libraryofcongress
   - M-O-S-E-S


### PR DESCRIPTION
Hello! Although I am not part of the U.S. Internal Revenue Service, I am submitting this addition for inclusion. In particular, this new organization includes the [Direct File system/application](https://github.com/IRS-Public/direct-file) actively in use by the IRS.

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _Internal Revenue Service_  
**GitHub Organization url**: _@IRS-public_  
**Country/Locality**: _U.S. Federal_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [ ] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [ ] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
