### PR TITLE
Redirect `/fedramp`

### DIFF
--- a/fedramp.md
+++ b/fedramp.md
@@ -7,4 +7,5 @@ form-id: 88570519
 campaign: "Fedramp Lead Form"
 sf-campaign-id: 7010V000002K5vw
 permalink: /fedramp/
+redirect_to: https://github.com/solutions/industry/government
 ---


### PR DESCRIPTION
- Towards: https://github.com/github/brand-and-marketing-epd/issues/718

 
This pull request adds a redirect link to the `fedramp.md` file, ensuring users visiting the `/fedramp` page are redirected to the relevant GitHub Solutions page for government industry, https://github.com/solutions/industry/government