### PR TITLE
Update IRS repository in governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -911,7 +911,7 @@ U.S. Federal:
   - Innovation-Toolkit
   - internationaltradeadministration
   - ioos
-  - IRSgov
+  - IRS-Public
   - keplergo
   - libraryofcongress
   - M-O-S-E-S


### PR DESCRIPTION
In compliance with the SHARE IT act, the IRS has recently open sourced https://github.com/IRS-Public/direct-file. This repository is the official repository of the IRS and replaces the incorrect https://github.com/orgs/IRSgov/

Thanks for the contribution! **Below** is a template that can make it easier when submitting your Organization:

**Your Organization**: _ACME Agency_  
**GitHub Organization url**: _@acmeagency_  
**Country/Locality**: _Alberta, Canada_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [ ] If this is a government project, your Organization's description should include a reference to your country/agency.
- [ ] Make sure your Organization includes at least one public repository
- [ ] Please also include a URL for your organization that links back to your organization or agency homepage.
 
^ If you want to convert your account to an org, details can be found here: https://help.github.com/articles/converting-a-user-into-an-organization/
  
 :heart: GitHub Government Contributors
