### PR TITLE
chore: add Planning-Inspectorate to governments.yml

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -712,6 +712,7 @@ U.K. Central:
   - openregister
   - OrdnanceSurvey
   - osgeouk
+  - Planning-Inspectorate
   - scottishgovernment
   - SkillsFundingAgency
   - tanc-ahrc


### PR DESCRIPTION
I have added the following:

**Your Organization**: Planning-Inspectorate
**GitHub Organization url**: _@Planning-Inspectorate_  
**Country/Locality**: _United Kingdom_

Inclusion requirements:
- [x] Referenced account is an [Organization](https://github.com/github/government.github.com#add-organization) not a User^
- [x] If this is a government project, your Organization's description should include a reference to your country/agency.
- [x] Make sure your Organization includes at least one public repository
- [x] Please also include a URL for your organization that links back to your organization or agency homepage.
 
