### PR TITLE
Add NC-DIT-Open-Source to U.S. States

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -1071,6 +1071,7 @@ U.S. States:
   - massgov
   - MESMD
   - MFWP-GIS
+  - NC-DIT-Open-Source
   - nebraskamap
   - nelegislature
   - NJOGIS


### PR DESCRIPTION
Adds the **NC-DIT-Open-Source** GitHub organization to the `U.S. States` section of `_data/governments.yml` so it appears on the [Community](https://government.github.com/community/) page.

This is the open-source org of the **North Carolina Department of Information Technology (NC DIT), Office of AI & Policy (OAIP)**. It hosts civic-tech tools built for and shared with government — starting with a public-comment analysis application, with more releases planned.

- Org: https://github.com/NC-DIT-Open-Source
- Entry placed alphabetically within the `U.S. States` list.
- Single-line addition; no other changes.