### PR TITLE
Update Norway: rename StatensPensjonskasse to live handle statens-pensjonskasse

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -482,7 +482,7 @@ Norway:
   - rutebanken
   - ruterno
   - Skatteetaten
-  - StatensPensjonskasse
+  - statens-pensjonskasse
   - statisticsnorway
   - telemark
   - telemark-arkiv


### PR DESCRIPTION
### What & why

The `StatensPensjonskasse` handle in `_data/governments.yml` (under **Norway**) now returns a 404 — the organization moved to a new handle.

**Statens pensjonskasse** — Norway's largest provider of state pensions — is now at [`statens-pensjonskasse`](https://github.com/statens-pensjonskasse) (28 public repositories, profile bio: *"Statens pensjonskasse - the largest provider of state pensions to the Norwegian people"*).

This updates the entry so the listing points to the live organization instead of a dead link. The new handle keeps the same alphabetical position in the Norway list.

### Verification
- Old: https://github.com/StatensPensjonskasse → 404
- New: https://github.com/statens-pensjonskasse → 200 (official Statens pensjonskasse org)

Single-line change; no other entries touched.