### PR TITLE
Fix remaining broken org handles in governments.yml (2 renames, 3 removals)

### DIFF
--- a/_data/governments.yml
+++ b/_data/governments.yml
@@ -265,7 +265,7 @@ France:
   - clipos
   - clipos-archive
   - communaute-cimi
-  - culturecommunication
+  - culturegouv
   - cw-leia
   - DGFiP
   - diplomatiegouvfr
@@ -374,7 +374,6 @@ Italy:
   - TeamDigitale
 
 Japan:
-  - city-of-kobe
   - codefornamie
   - gsi-cyberjapan
   - nhohq
@@ -614,7 +613,7 @@ Sweden:
 Switzerland:
   - admin-ch
   - alv-ch
-  - BFS-SHS-MSAS
+  - BFS-Web
   - dsi-vd
   - FNSKtZH
   - geoadmin
@@ -741,7 +740,6 @@ U.K. Councils:
   - edinburghcouncil
   - essexcountycouncil
   - gmfrs
-  - GuildfordBC
   - HfdsCouncil
   - kentcc
   - LambethCouncil
@@ -909,7 +907,6 @@ U.S. Federal:
   - imls
   - informaticslab
   - Innovation-Toolkit
-  - internationaltradeadministration
   - ioos
   - IRSgov
   - keplergo


### PR DESCRIPTION
### What & why

Five organization handles in `_data/governments.yml` no longer resolve — each returns a **404** on both github.com and the API. This updates the two that have a confirmed official successor and removes the three that are genuinely gone, so the listing stops pointing at dead links.

Each change was verified against the org's GitHub profile and its linked official government domain:

| Country | Old handle (404) | Action | Successor / rationale |
|---|---|---|---|
| France | `culturecommunication` | ✏️ rename → [`culturegouv`](https://github.com/culturegouv) | Org "Ministère de la Culture", 12 repos, links to **culture.gouv.fr** |
| Switzerland | `BFS-SHS-MSAS` | ✏️ rename → [`BFS-Web`](https://github.com/BFS-Web) | Org "Bundesamt für Statistik – Web Diffusion", links to **bfs.admin.ch** |
| Japan | `city-of-kobe` | 🗑️ remove | No official City of Kobe org (only civic-community/personal accounts) |
| U.K. Councils | `GuildfordBC` | 🗑️ remove | Handle gone; no replacement org for the council |
| U.S. Federal | `internationaltradeadministration` | 🗑️ remove | Org and its Pages developer portal deleted; no successor |

**One note for maintainers:** the Swiss `BFS-Web` org is official (admin.ch domain) but was created recently and currently has no public repos yet. Happy to drop that entry and keep it a straight removal instead if you'd prefer only orgs with published repos — let me know.

Verified: all five old handles 404; both successor orgs return 200 and link back to official government domains.